### PR TITLE
Make admin policy migrations replay-safe

### DIFF
--- a/supabase/migrations/20250124000000_admin_security.sql
+++ b/supabase/migrations/20250124000000_admin_security.sql
@@ -20,10 +20,12 @@ CREATE TABLE IF NOT EXISTS public.admin_audit_log (
 ALTER TABLE public.admin_audit_log ENABLE ROW LEVEL SECURITY;
 
 -- Only service role can read audit logs (for investigations)
+DROP POLICY IF EXISTS "Service role reads audit log" ON public.admin_audit_log;
 CREATE POLICY "Service role reads audit log" ON public.admin_audit_log
   FOR SELECT TO service_role USING (true);
 
 -- Admins can insert their own audit entries
+DROP POLICY IF EXISTS "Admins can log their actions" ON public.admin_audit_log;
 CREATE POLICY "Admins can log their actions" ON public.admin_audit_log
   FOR INSERT TO authenticated
   WITH CHECK (
@@ -119,19 +121,21 @@ ORDER BY u.created_at DESC;
 -- ================================================================
 
 -- Allow admins to UPDATE bills (for panel reviews)
+DROP POLICY IF EXISTS "Admins can update bills" ON public.bills;
 CREATE POLICY "Admins can update bills" ON public.bills
   FOR UPDATE TO authenticated
   USING (EXISTS (SELECT 1 FROM public.app_admins WHERE user_id = auth.uid()))
   WITH CHECK (EXISTS (SELECT 1 FROM public.app_admins WHERE user_id = auth.uid()));
 
 -- Allow admins to MANAGE translations (Insert/Update/Delete)
+DROP POLICY IF EXISTS "Admins can manage translations" ON public.bill_translations;
 CREATE POLICY "Admins can manage translations" ON public.bill_translations
   FOR ALL TO authenticated
   USING (EXISTS (SELECT 1 FROM public.app_admins WHERE user_id = auth.uid()))
   WITH CHECK (EXISTS (SELECT 1 FROM public.app_admins WHERE user_id = auth.uid()));
 
 -- Allow admins to VIEW ALL audit logs
+DROP POLICY IF EXISTS "Admins can view all audit logs" ON public.admin_audit_log;
 CREATE POLICY "Admins can view all audit logs" ON public.admin_audit_log
   FOR SELECT TO authenticated
   USING (EXISTS (SELECT 1 FROM public.app_admins WHERE user_id = auth.uid()));
-

--- a/supabase/migrations/20250125000001_fix_admin_rls.sql
+++ b/supabase/migrations/20250125000001_fix_admin_rls.sql
@@ -8,6 +8,7 @@ ALTER TABLE public.bill_translations ENABLE ROW LEVEL SECURITY;
 
 -- 2. Drop existing policies to avoid conflicts/duplication
 DROP POLICY IF EXISTS "Service role reads audit log" ON public.admin_audit_log;
+DROP POLICY IF EXISTS "Service role full access audit log" ON public.admin_audit_log;
 DROP POLICY IF EXISTS "Admins can log their actions" ON public.admin_audit_log;
 DROP POLICY IF EXISTS "Admins can view all audit logs" ON public.admin_audit_log;
 DROP POLICY IF EXISTS "Admins can manage translations" ON public.bill_translations;

--- a/supabase/migrations/20250125000001_fix_admin_rls.sql
+++ b/supabase/migrations/20250125000001_fix_admin_rls.sql
@@ -40,6 +40,7 @@ CREATE POLICY "Admins can manage translations" ON public.bill_translations
 -- Public Read Access (if needed for the app, usually public needs to read translations)
 -- Assuming public needs to read translations for the app to work?
 -- If not already defined, we should add it.
+DROP POLICY IF EXISTS "Public can view translations" ON public.bill_translations;
 CREATE POLICY "Public can view translations" ON public.bill_translations
   FOR SELECT TO anon, authenticated
   USING (true);


### PR DESCRIPTION
## Summary
- Makes older admin RLS migrations safe to replay in Supabase Preview branches by dropping matching policies before recreating them.
- Covers the duplicate `Admins can update bills` failure seen on PR 44 and a later public translation policy recreation hazard.
- Does not relax RLS or introduce new policies beyond the existing intended final state.

## Files changed
- `supabase/migrations/20250124000000_admin_security.sql`
- `supabase/migrations/20250125000001_fix_admin_rls.sql`

## Security considerations
- This preserves the existing admin-only and public-read policy definitions.
- No service-role grants, anon/authenticated grants, Vault access, or production data are changed.
- No secrets or `.env` values were read, printed, or committed.

## Database/migration considerations
- This edits previously checked-in migrations for replay idempotency; Supabase production should only apply new migration files, while preview branches replay the migration chain.
- The change is non-destructive for final schema state: each policy is recreated with the same policy definition already intended by the migration chain.

## Validation performed
- `git diff --check`
- Static search for duplicate `CREATE POLICY` statements across migrations and inspection of surrounding `DROP POLICY IF EXISTS` guards.
- Supabase Preview on this PR is expected to provide the replay validation.

## Rollback or roll-forward plan
- Rollback: revert this PR if the preview repair is not needed.
- Roll-forward: if Supabase Preview surfaces a later replay-only migration collision, add the same explicit idempotency guard to that migration without changing final RLS behavior.

## Remaining unknowns
- Local Supabase reset was not run because it would reset the local database; Supabase Preview will validate the branch replay in CI.
