### PR TITLE
[codex] add lnf privacy policy link

### DIFF
--- a/mobile-app/app/(tabs)/lnf.tsx
+++ b/mobile-app/app/(tabs)/lnf.tsx
@@ -9,8 +9,17 @@ import { ThemedView } from "../../components/ThemedView";
 import { ThemedText } from "../../components/ThemedText";
 import { Card, Button } from "react-native-paper";
 
-const FEED_URL = (process.env.EXPO_PUBLIC_LNF_URL?.trim() ||
-  "https://www.loveneverfailsus.com/") as string;
+const DEFAULT_LNF_URL = "https://www.loveneverfailsus.com/ai-advocate";
+const FEED_URL = (process.env.EXPO_PUBLIC_LNF_URL?.trim() || DEFAULT_LNF_URL) as string;
+const PRIVACY_POLICY_URL = "https://www.loveneverfailsus.com/ai-advocate/privacy-policy";
+
+async function openExternalUrl(url: string): Promise<void> {
+  try {
+    await Linking.openURL(url);
+  } catch (error) {
+    console.warn("Unable to open external URL", error);
+  }
+}
 
 export default function LnfScreen() {
   const { t } = useTranslation();
@@ -34,7 +43,7 @@ export default function LnfScreen() {
       >
         {Platform.OS === "web" ? (
           <Card mode="elevated" style={styles.heroCard}>
-            <Pressable onPress={() => Linking.openURL(FEED_URL)} style={{ flex: 1 }}>
+            <Pressable onPress={() => openExternalUrl(FEED_URL)} style={{ flex: 1 }}>
               <View style={styles.heroBody}>
                 <ThemedText type="title" style={{ marginBottom: 8 }}>
                   {t("lnf.webBestAtSource", { defaultValue: "Best experienced on the website" })}
@@ -45,7 +54,7 @@ export default function LnfScreen() {
                       "This publisher blocks embedding for security. Click below to open the feed directly.",
                   })}
                 </ThemedText>
-                <Button mode="contained" onPress={() => Linking.openURL(FEED_URL)}>
+                <Button mode="contained" onPress={() => openExternalUrl(FEED_URL)}>
                   {t("lnf.open", { defaultValue: "Open Feed" })}
                 </Button>
               </View>
@@ -59,6 +68,20 @@ export default function LnfScreen() {
             style={{ flex: 1 }}
           />
         )}
+
+        <View style={styles.policyButtonContainer}>
+          <Button
+            mode="text"
+            icon="shield-lock-outline"
+            onPress={() => openExternalUrl(PRIVACY_POLICY_URL)}
+            compact
+            accessibilityLabel={t("lnf.privacyPolicy", {
+              defaultValue: "Privacy Policy",
+            })}
+          >
+            {t("lnf.privacyPolicy", { defaultValue: "Privacy Policy" })}
+          </Button>
+        </View>
 
         {/* Admin Access Button */}
         <View style={styles.adminButtonContainer}>
@@ -86,6 +109,12 @@ const styles = StyleSheet.create({
   },
   heroCard: { flex: 1, justifyContent: "center" },
   heroBody: { flex: 1, justifyContent: "center", alignItems: "center", padding: 24, gap: 8 },
+  policyButtonContainer: {
+    position: "absolute",
+    bottom: 16,
+    left: 24,
+    opacity: 0.85,
+  },
   adminButtonContainer: {
     position: "absolute",
     bottom: 16,

--- a/mobile-app/app/(tabs)/lnf.tsx
+++ b/mobile-app/app/(tabs)/lnf.tsx
@@ -74,6 +74,7 @@ export default function LnfScreen() {
             mode="text"
             icon="shield-lock-outline"
             onPress={() => openExternalUrl(PRIVACY_POLICY_URL)}
+            style={styles.adminButton}
             compact
             accessibilityLabel={t("lnf.privacyPolicy", {
               defaultValue: "Privacy Policy",
@@ -113,7 +114,7 @@ const styles = StyleSheet.create({
     position: "absolute",
     bottom: 16,
     left: 24,
-    opacity: 0.85,
+    opacity: 0.7,
   },
   adminButtonContainer: {
     position: "absolute",

--- a/mobile-app/src/locales/en.json
+++ b/mobile-app/src/locales/en.json
@@ -77,7 +77,8 @@
     "openSite": "Open loveneverfailsus.com",
     "webBestAtSource": "Best experienced on the website",
     "webCspNote": "This publisher blocks embedding for security. Click below to open the feed directly.",
-    "open": "Open Feed"
+    "open": "Open Feed",
+    "privacyPolicy": "Privacy Policy"
   },
   "notFound": { "title": "This screen does not exist.", "homeCta": "Go to home screen!" },
   "party": {

--- a/mobile-app/src/locales/es.json
+++ b/mobile-app/src/locales/es.json
@@ -80,7 +80,8 @@
     "openSite": "Abrir loveneverfailsus.com",
     "webBestAtSource": "Se disfruta mejor en el sitio web",
     "webCspNote": "Este editor bloquea la incrustación por seguridad. Haz clic abajo para abrir el feed directamente.",
-    "open": "Abrir feed"
+    "open": "Abrir feed",
+    "privacyPolicy": "Política de privacidad"
   },
   "notFound": { "title": "Esta pantalla no existe.", "homeCta": "¡Ir a la pantalla principal!" },
   "party": {


### PR DESCRIPTION
Summary
- Adds an in-app Privacy Policy control to the existing LNF tab screen.
- Updates the default LNF WebView URL fallback to the AI Advocate LNF page.
- Adds maintained English and Spanish i18n strings for the new control.

Files changed
- mobile-app/app/(tabs)/lnf.tsx
- mobile-app/src/locales/en.json
- mobile-app/src/locales/es.json

User impact
- The LNF footer tab still opens the existing LNF screen.
- Users can access the AI Advocate privacy policy from a visible bottom-left button in the LNF screen.
- External link failures are caught and logged instead of crashing the app.

Security considerations
- No secrets added or exposed.
- Uses only public URLs.

Database/migration considerations
- None.

Validation performed
- cd mobile-app && npm run typecheck
- cd mobile-app && npm run lint (passed with existing warnings)
- cd mobile-app && npm test -- --runInBand
- cd mobile-app && npm run check:public-env
- cd mobile-app && node -e "JSON.parse(require('fs').readFileSync('eas.json','utf8')); JSON.parse(require('fs').readFileSync('store.config.json','utf8')); console.log('JSON OK')"
- cd mobile-app && eas --version

Manual verification steps
- Open the LNF footer tab.
- Confirm the LNF screen loads https://www.loveneverfailsus.com/ai-advocate by default.
- Tap Privacy Policy and confirm it opens https://www.loveneverfailsus.com/ai-advocate/privacy-policy.

Rollback or roll-forward plan
- Revert this PR to remove the button and restore the prior LNF fallback URL.

Remaining unknowns
- Not runtime-verified on a device in this PR.

Follow-ups
- Store metadata and EAS production config are handled in separate PRs.