### PR TITLE
[codex] update store privacy policy url

### DIFF
--- a/mobile-app/store.config.json
+++ b/mobile-app/store.config.json
@@ -9,7 +9,7 @@
         "keywords": ["legal", "ai", "assistant"],
         "marketingUrl": "https://www.loveneverfailsus.com/",
         "supportUrl": "https://www.loveneverfailsus.com/ai-advocate",
-        "privacyPolicyUrl": "https://www.loveneverfailsus.com/ai-advocate-privacy"
+        "privacyPolicyUrl": "https://www.loveneverfailsus.com/ai-advocate/privacy-policy"
       }
     }
   }


### PR DESCRIPTION
Summary
- Updates App Store submission metadata to use the AI Advocate privacy-policy URL.

Files changed
- mobile-app/store.config.json

User impact
- App Store Connect metadata points to the same privacy policy URL exposed in-app.

Security considerations
- No secrets added or exposed.
- Only a public policy URL changed.

Database/migration considerations
- None.

Validation performed
- cd mobile-app && npm run typecheck
- cd mobile-app && npm run lint (passed with existing warnings)
- cd mobile-app && npm test -- --runInBand
- cd mobile-app && npm run check:public-env
- cd mobile-app && node -e "JSON.parse(require('fs').readFileSync('eas.json','utf8')); JSON.parse(require('fs').readFileSync('store.config.json','utf8')); console.log('JSON OK')"
- cd mobile-app && eas --version

Manual verification steps
- Confirm mobile-app/store.config.json has privacyPolicyUrl set to https://www.loveneverfailsus.com/ai-advocate/privacy-policy.

Rollback or roll-forward plan
- Revert this PR to restore the prior store metadata URL.

Remaining unknowns
- Not verified in App Store Connect after submission.

Follow-ups
- EAS production config is handled in a separate PR.