### PR TITLE
[codex] harden eas production build config

### DIFF
--- a/mobile-app/eas.json
+++ b/mobile-app/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
-    "version": ">= 9.0.0",
-    "appVersionSource": "local"
+    "version": ">= 12.0.0",
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {
@@ -21,9 +21,14 @@
     },
     "production": {
       "channel": "production",
+      "autoIncrement": true,
       "env": {
         "EXPO_PUBLIC_SUPABASE_URL": "${EXPO_PUBLIC_SUPABASE_URL}",
-        "EXPO_PUBLIC_SUPABASE_ANON_KEY": "${EXPO_PUBLIC_SUPABASE_ANON_KEY}"
+        "EXPO_PUBLIC_SUPABASE_ANON_KEY": "${EXPO_PUBLIC_SUPABASE_ANON_KEY}",
+        "EXPO_PUBLIC_LNF_URL": "https://www.loveneverfailsus.com/ai-advocate"
+      },
+      "ios": {
+        "image": "macos-sequoia-15.6-xcode-26.2"
       },
       "android": {
         "buildType": "app-bundle"


### PR DESCRIPTION
Summary
- Switches EAS app versioning to remote with CLI >= 12.0.0.
- Enables production auto-increment and pins the requested production iOS build image.
- Adds the public LNF URL to production EAS env while preserving existing development, preview, and submit profiles.

Files changed
- mobile-app/eas.json

User impact
- Future production builds use the hardened iOS image and include the correct public LNF page URL.
- Existing development, preview, and submit workflows remain available.

Security considerations
- No secrets added or exposed.
- Supabase values remain environment placeholders.
- EXPO_PUBLIC_LNF_URL is public and safe to commit.

Database/migration considerations
- None.

Validation performed
- cd mobile-app && npm run typecheck
- cd mobile-app && npm run lint (passed with existing warnings)
- cd mobile-app && npm test -- --runInBand
- cd mobile-app && npm run check:public-env
- cd mobile-app && node -e "JSON.parse(require('fs').readFileSync('eas.json','utf8')); JSON.parse(require('fs').readFileSync('store.config.json','utf8')); console.log('JSON OK')"
- cd mobile-app && eas --version
- cd mobile-app && eas whoami
- cd mobile-app && eas build:inspect --platform ios --profile production --stage archive --output /tmp/aiadvocate-eas-inspect-ios-production --force

Manual verification steps
- Confirm mobile-app/eas.json preserves development, preview, and submit.production profiles.
- Confirm production iOS image is macos-sequoia-15.6-xcode-26.2.
- Confirm production env contains EXPO_PUBLIC_LNF_URL=https://www.loveneverfailsus.com/ai-advocate.

Rollback or roll-forward plan
- Revert this PR to restore previous EAS production configuration.

Remaining unknowns
- No production build was started. Remote app versioning initialization still needs to be confirmed before the next production iOS build.

Follow-ups
- Run cd mobile-app && eas build:version:set before the next production iOS build if remote app versioning has not already been initialized.