### PR TITLE
feat(push): wire upcoming-vote notifications (PR 2/3)

### DIFF
--- a/supabase/functions/send-push-notifications/index.ts
+++ b/supabase/functions/send-push-notifications/index.ts
@@ -183,12 +183,22 @@ serve(async (req) => {
       }
     }
 
+    // Expo returns HTTP 200 with a push *ticket* per message even when the push
+    // was rejected (status "error", e.g. DeviceNotRegistered / MessageRateExceeded),
+    // so a non-empty `tickets` does not mean anything was delivered. Count only
+    // accepted ("ok") tickets -- the real "delivery confirmed" signal.
+    const acceptedCount = tickets.filter(
+      (ticket) =>
+        !!ticket && typeof ticket === "object" &&
+        (ticket as { status?: unknown }).status === "ok",
+    ).length;
+
     // Delivery-confirmed dedup: record the ledger row only after at least one
-    // Expo ticket was accepted, and only for scheduler calls that supplied the
-    // event date. If every batch failed (tickets.length === 0), the row is left
+    // Expo ticket was accepted (acceptedCount > 0), and only for scheduler calls
+    // that supplied the event date. If nothing was accepted, the row is left
     // absent so notify_upcoming_votes retries on its next run. Per (bill, event
     // date), so a partially-failed fan-out is not re-sent to everyone.
-    if (eventDate && tickets.length > 0) {
+    if (eventDate && acceptedCount > 0) {
       const { error: ledgerError } = await supabaseAdmin
         .from("push_notification_log")
         .upsert({ bill_id: billId, event_date: eventDate }, { onConflict: "bill_id,event_date" });
@@ -201,7 +211,7 @@ serve(async (req) => {
       }
     }
 
-    return jsonResponse({ sent: tickets.length, failedBatches, tickets });
+    return jsonResponse({ sent: acceptedCount, failedBatches, tickets });
   } catch (error) {
     // Log details server-side; return a generic message so internal error
     // details (and any stack information) are not exposed to the caller.

--- a/supabase/functions/send-push-notifications/index.ts
+++ b/supabase/functions/send-push-notifications/index.ts
@@ -47,6 +47,17 @@ serve(async (req) => {
     if (billId === undefined || billId === null || billId === "") {
       throw new Error("Missing 'billId'");
     }
+    // Optional context from the upcoming-vote scheduler (notify_upcoming_votes):
+    //  - eventDate: the calendar date (YYYY-MM-DD) this notification is for. When
+    //    present, the dedup ledger row is written only AFTER a confirmed send, so
+    //    a failed/blocked delivery is retried on the scheduler's next run rather
+    //    than being permanently suppressed.
+    //  - eventLabel: the calendar entry's type/description, rendered in the title.
+    const eventDate = typeof body?.eventDate === "string" && body.eventDate.trim()
+      ? body.eventDate.trim()
+      : null;
+    const rawEventLabel = typeof body?.eventLabel === "string" ? body.eventLabel.trim() : "";
+    const eventLabel = (rawEventLabel || "activity").slice(0, 50);
 
     // 1. Get the bill details
     const { data: bill, error: billError } = await supabaseAdmin
@@ -127,7 +138,7 @@ serve(async (req) => {
     const messages = pushTokens.map((token: string) => ({
       to: token,
       sound: "default",
-      title: `Upcoming Vote on ${bill.bill_number ?? "a tracked bill"}`,
+      title: `Upcoming ${eventLabel}: ${bill.bill_number ?? "a tracked bill"}`,
       body: bill.title ?? "",
       data: { billId },
     }));
@@ -168,6 +179,24 @@ serve(async (req) => {
         console.error(
           `send-push-notifications: Expo batch ${batchIndex} threw:`,
           describeError(batchError),
+        );
+      }
+    }
+
+    // Delivery-confirmed dedup: record the ledger row only after at least one
+    // Expo ticket was accepted, and only for scheduler calls that supplied the
+    // event date. If every batch failed (tickets.length === 0), the row is left
+    // absent so notify_upcoming_votes retries on its next run. Per (bill, event
+    // date), so a partially-failed fan-out is not re-sent to everyone.
+    if (eventDate && tickets.length > 0) {
+      const { error: ledgerError } = await supabaseAdmin
+        .from("push_notification_log")
+        .upsert({ bill_id: billId, event_date: eventDate }, { onConflict: "bill_id,event_date" });
+      if (ledgerError) {
+        // Non-fatal: a missing ledger row only risks a duplicate on the next run.
+        console.error(
+          "send-push-notifications: failed recording push_notification_log:",
+          describeError(ledgerError),
         );
       }
     }

--- a/supabase/migrations/20260618130000_wire_upcoming_vote_push.sql
+++ b/supabase/migrations/20260618130000_wire_upcoming_vote_push.sql
@@ -3,8 +3,13 @@
 -- Wire push notifications: nothing currently invokes the send-push-notifications
 -- Edge Function, so registered Expo tokens never receive anything. This adds a
 -- daily pg_cron job that finds bookmarked bills with an UPCOMING calendar entry
--- and POSTs { billId } to send-push-notifications for each, deduplicating so a
--- given (bill, event date) notifies its bookmarkers at most once.
+-- and POSTs { billId, eventDate, eventLabel } to send-push-notifications for
+-- each. Dedup is delivery-confirmed: the Edge Function records
+-- push_notification_log(bill_id, event_date) only after a successful Expo send,
+-- so a failed/blocked delivery is retried on the next run (within the event
+-- window) instead of being permanently suppressed. eventLabel (the calendar
+-- entry's type/description) lets the push title name the actual event type
+-- rather than always saying "Vote".
 --
 -- Depends on (deploy first): the push-notification auth + RLS hardening PR
 --   - user_push_tokens RLS policy (so tokens are actually stored), and
@@ -66,10 +71,9 @@ DECLARE
   sync_secret TEXT;
   req_headers JSONB;
   request_id  BIGINT;
-  notified    INT := 0;
+  enqueued    INT := 0;
   window_days INT := GREATEST(COALESCE(p_window_days, 1), 0);
   rec         RECORD;
-  v_event_date DATE;
 BEGIN
   -- functions_base_url: Vault first, then app_config (non-secret URL config).
   SELECT v.decrypted_secret INTO base_url
@@ -126,18 +130,32 @@ BEGIN
     'Authorization', 'Bearer ' || sync_secret
   );
 
-  -- Candidate (bill, date string) pairs: bookmarked bills with a calendar entry
-  -- in the [today, today+window] range. Notes on the deliberate hardening:
-  --   * jsonb_array_elements is fed a CASE-guarded value: a set-returning
-  --     function in the FROM/LATERAL is evaluated during the join (before WHERE),
-  --     so a non-array calendar would throw unless guarded here.
-  --   * The range filter uses string comparison (YYYY-MM-DD sorts chronologically),
-  --     so no date cast happens in the query itself.
-  --   * The date cast and the dedup check are done per-row INSIDE the loop's
-  --     BEGIN ... EXCEPTION block, so a single malformed date (e.g. 2026-02-31)
-  --     only skips that bill instead of aborting the whole run.
+  -- Candidate (bill, date, label) rows: bookmarked bills with a calendar entry
+  -- in the [today, today+window] range that have NOT yet been recorded as
+  -- delivered. Hardening notes:
+  --   * jsonb_array_elements is fed a CASE-guarded value (a set-returning
+  --     function in the FROM/LATERAL is evaluated during the join, before WHERE),
+  --     so a non-array calendar cannot throw.
+  --   * The window filter AND the dedup check compare dates AS TEXT (YYYY-MM-DD
+  --     sorts chronologically), so no untrusted calendar value is ever cast to
+  --     date here -- a malformed date string cannot abort the run.
+  --   * The dedup row is written by send-push-notifications AFTER a confirmed
+  --     send (delivery-confirmed dedup), NOT here, so a failed/blocked delivery
+  --     is retried on the next run rather than permanently suppressed.
+  -- DISTINCT ON (bill, date) collapses multiple same-day calendar entries to a
+  -- single notification (one label, chosen deterministically), so a bill with
+  -- e.g. a hearing and a reading on the same day is not pushed twice in one run.
   FOR rec IN
-    SELECT DISTINCT b.id AS bill_id, elem->>'date' AS event_date_str
+    SELECT DISTINCT ON (b.id, elem->>'date')
+      b.id AS bill_id,
+      elem->>'date' AS event_date_str,
+      COALESCE(
+        NULLIF(btrim(elem->>'type'), ''),
+        NULLIF(btrim(elem->>'description'), ''),
+        NULLIF(btrim(elem->>'desc'), ''),
+        NULLIF(btrim(elem->>'event'), ''),
+        'activity'
+      ) AS event_label
     FROM public.bills AS b
     CROSS JOIN LATERAL jsonb_array_elements(
       CASE WHEN jsonb_typeof(b.calendar) = 'array' THEN b.calendar ELSE '[]'::jsonb END
@@ -146,51 +164,47 @@ BEGIN
       AND elem->>'date' >= to_char(current_date, 'YYYY-MM-DD')
       AND elem->>'date' <= to_char(current_date + window_days, 'YYYY-MM-DD')
       AND EXISTS (SELECT 1 FROM public.bookmarks AS bm WHERE bm.bill_id = b.id)
-    ORDER BY event_date_str, b.id
+      AND NOT EXISTS (
+        SELECT 1 FROM public.push_notification_log AS l
+        WHERE l.bill_id = b.id AND l.event_date::text = elem->>'date'
+      )
+    ORDER BY b.id, elem->>'date', event_label
   LOOP
     BEGIN
-      -- Cast inside the handler: a bad value skips this bill, not the whole run.
-      v_event_date := rec.event_date_str::date;
-
-      IF EXISTS (
-        SELECT 1 FROM public.push_notification_log AS l
-        WHERE l.bill_id = rec.bill_id AND l.event_date = v_event_date
-      ) THEN
-        CONTINUE;  -- already notified for this (bill, event date)
-      END IF;
-
+      -- Pass the event date + label so the function can render a per-event title
+      -- and write the dedup ledger only after a confirmed Expo send.
       SELECT net.http_post(
         url     := base_url || '/send-push-notifications',
         headers := req_headers,
-        body    := jsonb_build_object('billId', rec.bill_id)
+        body    := jsonb_build_object(
+          'billId', rec.bill_id,
+          'eventDate', rec.event_date_str,
+          'eventLabel', rec.event_label
+        )
       ) INTO request_id;
 
       IF request_id IS NULL THEN
         INSERT INTO public.cron_job_errors(job_name, error_message)
         VALUES ('notify-upcoming-votes',
                 'Invoke Error: send-push-notifications enqueue returned null for bill ' || rec.bill_id);
-        CONTINUE;  -- leave undedup'd so the next run retries
+        CONTINUE;
       END IF;
 
-      INSERT INTO public.push_notification_log(bill_id, event_date)
-      VALUES (rec.bill_id, v_event_date)
-      ON CONFLICT (bill_id, event_date) DO NOTHING;
-
-      notified := notified + 1;
+      enqueued := enqueued + 1;
     EXCEPTION WHEN OTHERS THEN
       INSERT INTO public.cron_job_errors(job_name, error_message)
       VALUES ('notify-upcoming-votes', 'Invoke Error: bill ' || rec.bill_id || ' failed: ' || SQLERRM);
     END;
   END LOOP;
 
-  RETURN notified;
+  RETURN enqueued;
 
 EXCEPTION WHEN OTHERS THEN
   -- Match invoke_edge_function: record unexpected failures rather than letting
   -- the cron run fail silently.
   INSERT INTO public.cron_job_errors(job_name, error_message)
   VALUES ('notify-upcoming-votes', 'Fatal: ' || SQLERRM);
-  RETURN notified;
+  RETURN enqueued;
 END;
 $$;
 
@@ -199,7 +213,7 @@ REVOKE ALL ON FUNCTION public.notify_upcoming_votes(INT) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.notify_upcoming_votes(INT) TO service_role;
 
 COMMENT ON FUNCTION public.notify_upcoming_votes(INT) IS
-  'Daily scheduler hook: POSTs { billId } to send-push-notifications for bookmarked bills with an upcoming calendar entry, deduped via push_notification_log.';
+  'Daily scheduler hook: enqueues send-push-notifications ({ billId, eventDate, eventLabel }) for bookmarked bills with an upcoming calendar entry not yet in push_notification_log. The Edge Function writes the dedup ledger only after a confirmed send, so failed/blocked deliveries retry on the next run. Returns the number enqueued.';
 
 -- ---------- Schedule (mirrors existing cron guard pattern) ----------
 -- 16:00 UTC (~08:00-09:00 America/Los_Angeles): a reasonable morning send.

--- a/supabase/migrations/20260618130000_wire_upcoming_vote_push.sql
+++ b/supabase/migrations/20260618130000_wire_upcoming_vote_push.sql
@@ -69,6 +69,7 @@ DECLARE
   notified    INT := 0;
   window_days INT := GREATEST(COALESCE(p_window_days, 1), 0);
   rec         RECORD;
+  v_event_date DATE;
 BEGIN
   -- functions_base_url: Vault first, then app_config (non-secret URL config).
   SELECT v.decrypted_secret INTO base_url
@@ -125,33 +126,39 @@ BEGIN
     'Authorization', 'Bearer ' || sync_secret
   );
 
-  -- Bookmarked bills whose calendar has an upcoming entry within the window and
-  -- that have not already been notified for that event date.
-  --
-  -- The event date is parsed inside a LATERAL whose WHERE guards the cast: it
-  -- only runs for fixed-format YYYY-MM-DD strings already constrained to the
-  -- [today, today+window] range (string comparison, since that ordering matches
-  -- chronological order), so an untrusted/malformed calendar value can never
-  -- throw a date-cast error and abort the run.
+  -- Candidate (bill, date string) pairs: bookmarked bills with a calendar entry
+  -- in the [today, today+window] range. Notes on the deliberate hardening:
+  --   * jsonb_array_elements is fed a CASE-guarded value: a set-returning
+  --     function in the FROM/LATERAL is evaluated during the join (before WHERE),
+  --     so a non-array calendar would throw unless guarded here.
+  --   * The range filter uses string comparison (YYYY-MM-DD sorts chronologically),
+  --     so no date cast happens in the query itself.
+  --   * The date cast and the dedup check are done per-row INSIDE the loop's
+  --     BEGIN ... EXCEPTION block, so a single malformed date (e.g. 2026-02-31)
+  --     only skips that bill instead of aborting the whole run.
   FOR rec IN
-    SELECT DISTINCT b.id AS bill_id, ev.event_date
+    SELECT DISTINCT b.id AS bill_id, elem->>'date' AS event_date_str
     FROM public.bills AS b
-    CROSS JOIN LATERAL jsonb_array_elements(b.calendar) AS elem
-    CROSS JOIN LATERAL (
-      SELECT (elem->>'date')::date AS event_date
-      WHERE elem->>'date' ~ '^\d{4}-\d{2}-\d{2}$'
-        AND elem->>'date' >= to_char(current_date, 'YYYY-MM-DD')
-        AND elem->>'date' <= to_char(current_date + window_days, 'YYYY-MM-DD')
-    ) AS ev
-    WHERE jsonb_typeof(b.calendar) = 'array'
+    CROSS JOIN LATERAL jsonb_array_elements(
+      CASE WHEN jsonb_typeof(b.calendar) = 'array' THEN b.calendar ELSE '[]'::jsonb END
+    ) AS elem
+    WHERE elem->>'date' ~ '^\d{4}-\d{2}-\d{2}$'
+      AND elem->>'date' >= to_char(current_date, 'YYYY-MM-DD')
+      AND elem->>'date' <= to_char(current_date + window_days, 'YYYY-MM-DD')
       AND EXISTS (SELECT 1 FROM public.bookmarks AS bm WHERE bm.bill_id = b.id)
-      AND NOT EXISTS (
-        SELECT 1 FROM public.push_notification_log AS l
-        WHERE l.bill_id = b.id AND l.event_date = ev.event_date
-      )
-    ORDER BY ev.event_date, b.id
+    ORDER BY event_date_str, b.id
   LOOP
     BEGIN
+      -- Cast inside the handler: a bad value skips this bill, not the whole run.
+      v_event_date := rec.event_date_str::date;
+
+      IF EXISTS (
+        SELECT 1 FROM public.push_notification_log AS l
+        WHERE l.bill_id = rec.bill_id AND l.event_date = v_event_date
+      ) THEN
+        CONTINUE;  -- already notified for this (bill, event date)
+      END IF;
+
       SELECT net.http_post(
         url     := base_url || '/send-push-notifications',
         headers := req_headers,
@@ -166,7 +173,7 @@ BEGIN
       END IF;
 
       INSERT INTO public.push_notification_log(bill_id, event_date)
-      VALUES (rec.bill_id, rec.event_date)
+      VALUES (rec.bill_id, v_event_date)
       ON CONFLICT (bill_id, event_date) DO NOTHING;
 
       notified := notified + 1;

--- a/supabase/migrations/20260618130000_wire_upcoming_vote_push.sql
+++ b/supabase/migrations/20260618130000_wire_upcoming_vote_push.sql
@@ -1,0 +1,211 @@
+-- 20260618130000_wire_upcoming_vote_push.sql
+--
+-- Wire push notifications: nothing currently invokes the send-push-notifications
+-- Edge Function, so registered Expo tokens never receive anything. This adds a
+-- daily pg_cron job that finds bookmarked bills with an UPCOMING calendar entry
+-- and POSTs { billId } to send-push-notifications for each, deduplicating so a
+-- given (bill, event date) notifies its bookmarkers at most once.
+--
+-- Depends on (deploy first): the push-notification auth + RLS hardening PR
+--   - user_push_tokens RLS policy (so tokens are actually stored), and
+--   - send-push-notifications running with verify_jwt = false +
+--     isAuthorizedCronOrAdmin(), so the scheduler's SYNC_SECRET bearer token is
+--     accepted (this job sends exactly that header).
+--
+-- Secret resolution reads vault.decrypted_secrets DIRECTLY (like
+-- is_valid_bill_sync_secret and the restored invoke_edge_function) rather than
+-- vault.get_secret(...), which AGENTS.md documents as historically absent.
+--
+-- Calendar shape (confirmed by mobile-app/src/lib/billStatus.ts): bills.calendar
+-- is a JSONB array of entries { "date": "YYYY-MM-DD", "time"?, "type"?, ... }.
+
+-- ---------- Dedup log (internal / service-role only) ----------
+CREATE TABLE IF NOT EXISTS public.push_notification_log (
+  bill_id     BIGINT NOT NULL REFERENCES public.bills(id) ON DELETE CASCADE,
+  event_date  DATE   NOT NULL,
+  notified_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (bill_id, event_date)
+);
+
+COMMENT ON TABLE public.push_notification_log IS
+  'Dedup ledger for upcoming-vote push notifications: one row per (bill, event date) already notified.';
+
+ALTER TABLE public.push_notification_log ENABLE ROW LEVEL SECURITY;
+
+-- Clients have no business touching this ledger; only the service role (and the
+-- SECURITY DEFINER RPC below, which bypasses RLS) reads/writes it.
+REVOKE ALL ON TABLE public.push_notification_log FROM PUBLIC;
+REVOKE ALL ON TABLE public.push_notification_log FROM anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.push_notification_log TO service_role;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'push_notification_log'
+      AND policyname = 'Service role manages push log'
+  ) THEN
+    CREATE POLICY "Service role manages push log" ON public.push_notification_log
+      FOR ALL USING (auth.role() = 'service_role') WITH CHECK (auth.role() = 'service_role');
+  END IF;
+END $$;
+
+-- ---------- Invocation RPC ----------
+-- p_window_days: how many days ahead to look. Default 1 => events dated today or
+-- tomorrow. Run daily, dedup means each event notifies ~1 day out, exactly once.
+CREATE OR REPLACE FUNCTION public.notify_upcoming_votes(p_window_days INT DEFAULT 1)
+RETURNS INT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  base_url    TEXT;
+  anon_key    TEXT;
+  sync_secret TEXT;
+  req_headers JSONB;
+  request_id  BIGINT;
+  notified    INT := 0;
+  window_days INT := GREATEST(COALESCE(p_window_days, 1), 0);
+  rec         RECORD;
+BEGIN
+  -- functions_base_url: Vault first, then app_config (non-secret URL config).
+  SELECT v.decrypted_secret INTO base_url
+  FROM vault.decrypted_secrets AS v
+  WHERE v.name = 'functions_base_url' AND NULLIF(v.decrypted_secret, '') IS NOT NULL
+  ORDER BY v.updated_at DESC NULLS LAST, v.created_at DESC NULLS LAST
+  LIMIT 1;
+
+  IF NULLIF(base_url, '') IS NULL THEN
+    SELECT c.value INTO base_url
+    FROM public.app_config AS c
+    WHERE c.key = 'functions_base_url' AND NULLIF(c.value, '') IS NOT NULL
+    LIMIT 1;
+  END IF;
+
+  IF NULLIF(base_url, '') IS NULL THEN
+    INSERT INTO public.cron_job_errors(job_name, error_message)
+    VALUES ('notify-upcoming-votes', 'Invoke Error: missing functions_base_url in Vault and app_config');
+    RETURN 0;
+  END IF;
+
+  SELECT v.decrypted_secret INTO anon_key
+  FROM vault.decrypted_secrets AS v
+  WHERE v.name IN ('supabase_anon_key', 'anon_key') AND NULLIF(v.decrypted_secret, '') IS NOT NULL
+  ORDER BY CASE v.name WHEN 'supabase_anon_key' THEN 0 WHEN 'anon_key' THEN 1 ELSE 2 END,
+           v.updated_at DESC NULLS LAST, v.created_at DESC NULLS LAST
+  LIMIT 1;
+
+  IF NULLIF(anon_key, '') IS NULL THEN
+    INSERT INTO public.cron_job_errors(job_name, error_message)
+    VALUES ('notify-upcoming-votes', 'Invoke Error: missing supabase_anon_key/anon_key');
+    RETURN 0;
+  END IF;
+
+  -- send-push-notifications authorizes the scheduler via the shared secret,
+  -- validated in-function against Vault (isAuthorizedCronOrAdmin / the pg_cron path).
+  SELECT v.decrypted_secret INTO sync_secret
+  FROM vault.decrypted_secrets AS v
+  WHERE v.name IN ('SYNC_SECRET', 'sync_secret', 'bill-sync-api-key') AND NULLIF(v.decrypted_secret, '') IS NOT NULL
+  ORDER BY CASE v.name WHEN 'SYNC_SECRET' THEN 0 WHEN 'sync_secret' THEN 1 WHEN 'bill-sync-api-key' THEN 2 ELSE 3 END,
+           v.updated_at DESC NULLS LAST, v.created_at DESC NULLS LAST
+  LIMIT 1;
+
+  IF NULLIF(sync_secret, '') IS NULL THEN
+    INSERT INTO public.cron_job_errors(job_name, error_message)
+    VALUES ('notify-upcoming-votes', 'Invoke Error: missing SYNC_SECRET/sync_secret/bill-sync-api-key');
+    RETURN 0;
+  END IF;
+
+  base_url := rtrim(base_url, '/');
+  req_headers := jsonb_build_object(
+    'Content-Type', 'application/json',
+    'apikey', anon_key,
+    'Authorization', 'Bearer ' || sync_secret
+  );
+
+  -- Bookmarked bills whose calendar has an upcoming entry within the window and
+  -- that have not already been notified for that event date.
+  --
+  -- The event date is parsed inside a LATERAL whose WHERE guards the cast: it
+  -- only runs for fixed-format YYYY-MM-DD strings already constrained to the
+  -- [today, today+window] range (string comparison, since that ordering matches
+  -- chronological order), so an untrusted/malformed calendar value can never
+  -- throw a date-cast error and abort the run.
+  FOR rec IN
+    SELECT DISTINCT b.id AS bill_id, ev.event_date
+    FROM public.bills AS b
+    CROSS JOIN LATERAL jsonb_array_elements(b.calendar) AS elem
+    CROSS JOIN LATERAL (
+      SELECT (elem->>'date')::date AS event_date
+      WHERE elem->>'date' ~ '^\d{4}-\d{2}-\d{2}$'
+        AND elem->>'date' >= to_char(current_date, 'YYYY-MM-DD')
+        AND elem->>'date' <= to_char(current_date + window_days, 'YYYY-MM-DD')
+    ) AS ev
+    WHERE jsonb_typeof(b.calendar) = 'array'
+      AND EXISTS (SELECT 1 FROM public.bookmarks AS bm WHERE bm.bill_id = b.id)
+      AND NOT EXISTS (
+        SELECT 1 FROM public.push_notification_log AS l
+        WHERE l.bill_id = b.id AND l.event_date = ev.event_date
+      )
+    ORDER BY ev.event_date, b.id
+  LOOP
+    BEGIN
+      SELECT net.http_post(
+        url     := base_url || '/send-push-notifications',
+        headers := req_headers,
+        body    := jsonb_build_object('billId', rec.bill_id)
+      ) INTO request_id;
+
+      IF request_id IS NULL THEN
+        INSERT INTO public.cron_job_errors(job_name, error_message)
+        VALUES ('notify-upcoming-votes',
+                'Invoke Error: send-push-notifications enqueue returned null for bill ' || rec.bill_id);
+        CONTINUE;  -- leave undedup'd so the next run retries
+      END IF;
+
+      INSERT INTO public.push_notification_log(bill_id, event_date)
+      VALUES (rec.bill_id, rec.event_date)
+      ON CONFLICT (bill_id, event_date) DO NOTHING;
+
+      notified := notified + 1;
+    EXCEPTION WHEN OTHERS THEN
+      INSERT INTO public.cron_job_errors(job_name, error_message)
+      VALUES ('notify-upcoming-votes', 'Invoke Error: bill ' || rec.bill_id || ' failed: ' || SQLERRM);
+    END;
+  END LOOP;
+
+  RETURN notified;
+
+EXCEPTION WHEN OTHERS THEN
+  -- Match invoke_edge_function: record unexpected failures rather than letting
+  -- the cron run fail silently.
+  INSERT INTO public.cron_job_errors(job_name, error_message)
+  VALUES ('notify-upcoming-votes', 'Fatal: ' || SQLERRM);
+  RETURN notified;
+END;
+$$;
+
+-- Internal scheduler RPC: not for anon/authenticated callers.
+REVOKE ALL ON FUNCTION public.notify_upcoming_votes(INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.notify_upcoming_votes(INT) TO service_role;
+
+COMMENT ON FUNCTION public.notify_upcoming_votes(INT) IS
+  'Daily scheduler hook: POSTs { billId } to send-push-notifications for bookmarked bills with an upcoming calendar entry, deduped via push_notification_log.';
+
+-- ---------- Schedule (mirrors existing cron guard pattern) ----------
+-- 16:00 UTC (~08:00-09:00 America/Los_Angeles): a reasonable morning send.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'notify-upcoming-votes') THEN
+    PERFORM cron.unschedule('notify-upcoming-votes');
+  END IF;
+END;
+$$;
+
+SELECT cron.schedule('notify-upcoming-votes', '0 16 * * *', 'SELECT public.notify_upcoming_votes()')
+WHERE NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'notify-upcoming-votes');
+
+-- New table changes the API surface; refresh PostgREST's schema cache.
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260618130000_wire_upcoming_vote_push.sql
+++ b/supabase/migrations/20260618130000_wire_upcoming_vote_push.sql
@@ -136,9 +136,12 @@ BEGIN
   --   * jsonb_array_elements is fed a CASE-guarded value (a set-returning
   --     function in the FROM/LATERAL is evaluated during the join, before WHERE),
   --     so a non-array calendar cannot throw.
-  --   * The window filter AND the dedup check compare dates AS TEXT (YYYY-MM-DD
-  --     sorts chronologically), so no untrusted calendar value is ever cast to
-  --     date here -- a malformed date string cannot abort the run.
+  --   * The regex rejects out-of-range month/day values; the window filter AND
+  --     the dedup check then compare dates AS TEXT (YYYY-MM-DD sorts
+  --     chronologically), so no untrusted calendar value is ever cast to date
+  --     here -- a malformed date string cannot abort the run. (A rare in-range
+  --     impossible date like 2026-02-30 is harmless: the Edge Function's DATE
+  --     upsert just skips the dedup row, at worst one duplicate while in-window.)
   --   * The dedup row is written by send-push-notifications AFTER a confirmed
   --     send (delivery-confirmed dedup), NOT here, so a failed/blocked delivery
   --     is retried on the next run rather than permanently suppressed.
@@ -160,7 +163,7 @@ BEGIN
     CROSS JOIN LATERAL jsonb_array_elements(
       CASE WHEN jsonb_typeof(b.calendar) = 'array' THEN b.calendar ELSE '[]'::jsonb END
     ) AS elem
-    WHERE elem->>'date' ~ '^\d{4}-\d{2}-\d{2}$'
+    WHERE elem->>'date' ~ '^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$'
       AND elem->>'date' >= to_char(current_date, 'YYYY-MM-DD')
       AND elem->>'date' <= to_char(current_date + window_days, 'YYYY-MM-DD')
       AND EXISTS (SELECT 1 FROM public.bookmarks AS bm WHERE bm.bill_id = b.id)


### PR DESCRIPTION
## Summary

Nothing currently invokes `send-push-notifications`, so even with tokens registered, no notification is ever sent. This adds a daily scheduler that notifies bookmarkers of **upcoming `calendar` events** on bills they follow.

Two behaviors were chosen by the maintainer and are implemented here:
- **Delivery-confirmed dedup (+ retry):** the dedup ledger is written only after a confirmed Expo send, so a failed/blocked delivery is retried on the next run rather than permanently suppressed.
- **Per-event copy:** the push title names the actual calendar event (`Upcoming <type>: <bill>`) instead of always saying "Vote".

> **Depends on PR #53 being deployed first** (and merged first — it edits the same `index.ts` in disjoint regions). This job sends `Authorization: Bearer <SYNC_SECRET>`, accepted only once `send-push-notifications` runs with `verify_jwt=false` + `isAuthorizedCronOrAdmin()` (PR 1b); recipients exist only once the `user_push_tokens` RLS policy (PR 1a) lets the app store tokens.

## Files changed

| File | Change |
|------|--------|
| `supabase/migrations/20260618130000_wire_upcoming_vote_push.sql` | New migration: dedup table `push_notification_log`, RPC `notify_upcoming_votes`, daily `pg_cron` job. |
| `supabase/functions/send-push-notifications/index.ts` | Accept optional `eventDate`/`eventLabel`; render per-event title; **write the dedup ledger only after ≥1 Expo ticket is accepted.** |

## How it works

1. **`notify_upcoming_votes()`** (SECURITY DEFINER, `search_path=public`) resolves `functions_base_url`/`anon_key`/`SYNC_SECRET` directly from `vault.decrypted_secrets` (not the historically-absent `vault.get_secret`).
2. It selects, **one row per `(bill, date)`** (`DISTINCT ON`), bookmarked bills with a `calendar` entry in `[today, today+window]` **not yet in `push_notification_log`**, deriving an `event_label` from the entry (`type`→`description`→`desc`→`event`, default `activity`).
3. For each, it enqueues `net.http_post` `{ billId, eventDate, eventLabel }` with the cron auth headers. It does **not** write the ledger.
4. **`send-push-notifications`** fans out to Expo and, on success (≥1 ticket), upserts `push_notification_log(bill_id, event_date)`. If every batch fails, no row is written → retried next run.

### Why the function records the ledger (not the cron)
`net.http_post` is async and only confirms *enqueue*. A daily job can't reuse `net._http_response` to confirm delivery later — pg_net prunes it (~6h) long before the next run. The Edge Function already `await`s the Expo response, so it's the right place to record *confirmed* delivery. (Addresses Codex P1.)

### Safety hardening
- `jsonb_array_elements` is `CASE`-guarded (non-array `calendar` can't throw). (Codex/gemini)
- The window filter **and** dedup check compare dates **as text** (`event_date::text = elem->>'date'`), so no untrusted calendar value is ever cast to `date` in the RPC — a malformed date can't abort the run. (Codex/gemini)
- `net.http_post` body stays `jsonb` (pg_net's signature; see `migrations/20260424103000`). The `::text` suggestion was declined.
- Per-iteration `BEGIN…EXCEPTION` + a top-level handler log to `cron_job_errors` like `invoke_edge_function`.

## Security considerations

- RPC is `SECURITY DEFINER` + explicit `search_path`, `EXECUTE` revoked from `PUBLIC` (service_role only).
- `push_notification_log` has RLS on, `anon`/`authenticated` revoked, service_role-only policy.
- No secret values are logged; secrets come from Vault.

## Validation performed

- Static review. Supabase Branching reports the migration applies cleanly + the function deploys on the preview branch. **Runtime behavior (actual sends, retries) is not verified** — I have no query access to the AI Advocate DB. Marked per AGENTS.md §14: **implemented, not runtime-verified.**

## Manual verification

```sql
-- Objects + schedule
SELECT to_regclass('public.push_notification_log'),
       to_regprocedure('public.notify_upcoming_votes(int)');
SELECT jobname, schedule, command FROM cron.job WHERE jobname = 'notify-upcoming-votes';

-- Dry-look: which (bill, date, label) would be sent today (no side effects)
SELECT DISTINCT ON (b.id, elem->>'date')
       b.id, elem->>'date' AS event_date,
       COALESCE(NULLIF(btrim(elem->>'type'),''), NULLIF(btrim(elem->>'description'),''), 'activity') AS label
FROM public.bills b
CROSS JOIN LATERAL jsonb_array_elements(CASE WHEN jsonb_typeof(b.calendar)='array' THEN b.calendar ELSE '[]'::jsonb END) elem
WHERE elem->>'date' ~ '^\d{4}-\d{2}-\d{2}$'
  AND elem->>'date' BETWEEN to_char(current_date,'YYYY-MM-DD') AND to_char(current_date+1,'YYYY-MM-DD')
  AND EXISTS (SELECT 1 FROM public.bookmarks bm WHERE bm.bill_id=b.id)
  AND NOT EXISTS (SELECT 1 FROM public.push_notification_log l WHERE l.bill_id=b.id AND l.event_date::text=elem->>'date')
ORDER BY b.id, elem->>'date', label;

-- Manual run (requires Vault secrets + #53 deployed). Returns # enqueued.
SELECT public.notify_upcoming_votes();

-- Confirm enqueue reached the function, then that the ledger filled in
SELECT id, status_code, created FROM net._http_response ORDER BY created DESC LIMIT 20;  -- expect 2xx
SELECT * FROM public.push_notification_log ORDER BY notified_at DESC LIMIT 20;            -- written by the function on success
SELECT * FROM public.cron_job_errors WHERE job_name='notify-upcoming-votes' ORDER BY occurred_at DESC LIMIT 20;
```

To verify retry-on-failure: run while #53 is NOT deployed (sends will 401) → `push_notification_log` stays empty → a later run re-enqueues.

## Rollback

```sql
SELECT cron.unschedule('notify-upcoming-votes');
DROP FUNCTION IF EXISTS public.notify_upcoming_votes(int);
DROP TABLE IF EXISTS public.push_notification_log;   -- dedup history only
NOTIFY pgrst, 'reload schema';
```
Revert the `index.ts` changes via git.

## Notes

- Trigger = `calendar` entries (matches the function's "upcoming" framing and the app's `billStatus.ts`). Window default 1 day; schedule `0 16 * * *` UTC — both adjustable.
- `vault.get_secret` regression: the latest pre-existing migration (`20260616200000`) calls it and it may be absent; this PR avoids that path. Worth a separate follow-up if cron ingestion is currently failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QR587GB9Q6o8K3XRMavKXF