### PR TITLE
fix(eas): set ascAppId for non-interactive iOS submit

### DIFF
--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -16,8 +16,7 @@
         "backgroundColor": "#151718"
       },
       "package": "com.loveneverfails.aiadvocate",
-      "googleServicesFile": "./google-services.json",
-      "versionCode": 2
+      "googleServicesFile": "./google-services.json"
     },
     "ios": {
       "supportsTablet": true,
@@ -25,8 +24,7 @@
       "googleServicesFile": "./GoogleService-Info.plist",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
-      },
-      "buildNumber": "1"
+      }
     },
     "web": {
       "bundler": "metro",

--- a/mobile-app/eas.json
+++ b/mobile-app/eas.json
@@ -38,6 +38,7 @@
   "submit": {
     "production": {
       "ios": {
+        "ascAppId": "6749104204",
         "metadataPath": "./store.config.json"
       },
       "android": {


### PR DESCRIPTION
## Summary
- The iOS build's auto-submit step failed with `Set ascAppId in the submit profile (eas.json) or re-run this command in interactive mode.` — non-interactive dashboard/CI submissions can't prompt to pick an App Store Connect app.
- Adds `submit.production.ios.ascAppId: "6749104204"` (App Store Connect "Apple ID" for AI Advocate) to `mobile-app/eas.json`.
- Drops the now-stale `ios.buildNumber` and `android.versionCode` fields from `mobile-app/app.json` — `appVersionSource: "remote"` ignores both in favor of EAS-tracked values; the build log flagged `ios.buildNumber` specifically as "recommended to remove," applied the same logic to Android for consistency.

## Test plan
- [x] Validated both JSON files parse correctly
- [x] CI (test-and-lint, CodeQL, GitGuardian) green
- [ ] Re-trigger iOS build from EAS dashboard after merge to confirm submit succeeds


---
_Generated by [Claude Code](https://claude.ai/code/session_01EV2sP8kD3o3bg2zdLiEzRD)_