### PR TITLE
feat(android): enable edge-to-edge and R8 shrinking for Play readiness

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -104,4 +104,4 @@ eas update --branch production --message "Fix: summary persistence and UI refine
 ## 🛠 Troubleshooting
 
 *   **Build Fails?** Check the logs provided in the Expo dashboard link.
-*   **Version Code Error?** Versions are managed remotely by EAS (`appVersionSource: "remote"` in `eas.json`), and production builds auto-increment `versionCode`/`buildNumber` on every build. Do not add these fields to `app.json` — adjust the user-facing version from the EAS dashboard (or `eas build:version:set`) instead.
+*   **Version Code Error?** Versions are managed remotely by EAS (`cli.appVersionSource: "remote"` in `eas.json`), and production builds auto-increment `versionCode`/`buildNumber` on every build. Do not add these fields to `app.json` — adjust the user-facing version from the EAS dashboard (or `eas build:version:set`) instead.

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -104,8 +104,4 @@ eas update --branch production --message "Fix: summary persistence and UI refine
 ## 🛠 Troubleshooting
 
 *   **Build Fails?** Check the logs provided in the Expo dashboard link.
-*   **Version Code Error?** Increment the `versionCode` (Android) or `buildNumber` (iOS) in `app.json` before building.
-    ```json
-    "android": { "versionCode": 2 },
-    "ios": { "buildNumber": "2" }
-    ```
+*   **Version Code Error?** Versions are managed remotely by EAS (`appVersionSource: "remote"` in `eas.json`), and production builds auto-increment `versionCode`/`buildNumber` on every build. Do not add these fields to `app.json` — adjust the user-facing version from the EAS dashboard (or `eas build:version:set`) instead.

--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -16,7 +16,8 @@
         "backgroundColor": "#151718"
       },
       "package": "com.loveneverfails.aiadvocate",
-      "googleServicesFile": "./google-services.json"
+      "googleServicesFile": "./google-services.json",
+      "edgeToEdgeEnabled": true
     },
     "ios": {
       "supportsTablet": true,
@@ -49,6 +50,10 @@
         {
           "ios": {
             "useFrameworks": "static"
+          },
+          "android": {
+            "enableProguardInReleaseBuilds": true,
+            "enableShrinkResourcesInReleaseBuilds": true
           }
         }
       ]
@@ -67,6 +72,8 @@
     "updates": {
       "url": "https://u.expo.dev/2815e517-2761-4f1b-a1d9-57dc978c3b0c"
     },
-    "runtimeVersion": "1.0.0"
+    "runtimeVersion": {
+      "policy": "fingerprint"
+    }
   }
 }


### PR DESCRIPTION
## Summary
Actions the Play Console pre-launch recommendations (which were generated against the old `1 (1.0.0)` binary):

- **Edge-to-edge** (`android.edgeToEdgeEnabled: true`): every screen already handles insets via `useSafeAreaInsets` — `HeaderBanner` pads `insets.top`, `FooterNav` pads `insets.bottom`, root has `SafeAreaProvider`, and no app code touches the deprecated `setStatusBarColor`/`setNavigationBarColor` APIs (those hits are all inside RN core/react-native-screens/dev-launcher). iOS has always rendered edge-to-edge with this same layout code, so Android is just opting into the path the app was already built for.
- **R8 code + resource shrinking** (`enableProguardInReleaseBuilds` + `enableShrinkResourcesInReleaseBuilds` via expo-build-properties): addresses the "Optimization score / Obfuscation score 2%" recommendation; smaller APK, obfuscated release code. Expo modules and RN ship their own consumer keep rules on SDK 53.
- **`runtimeVersion: { "policy": "fingerprint" }`**: replaces the static `"1.0.0"` so native-affecting changes (like these two) automatically segment OTA update compatibility instead of relying on remembering to hand-bump.
- **DEPLOYMENT_GUIDE.md**: corrects the stale troubleshooting advice to hand-edit `versionCode`/`buildNumber` in app.json (removed in #60; versions are remote-managed and auto-incremented by EAS).

Deliberately **not** changed: the portrait orientation lock (Android 16 ignores it on large screens anyway, so there's no compliance issue — unlocking is a product/UX decision that needs real tablet testing first).

## Test plan
- [x] `tsc --noEmit` clean
- [x] 13/13 Jest suites, 50/50 tests pass
- [x] app.json valid JSON
- [ ] These only take effect in the **next** EAS build — verify on the Play internal track before promoting (especially first R8 build: exercise auth, push notifications, hCaptcha, QR codes, webview)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EV2sP8kD3o3bg2zdLiEzRD)_