### PR TITLE
fix: harden the web-only admin split from PR #63 review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Check public env guardrail
         run: yarn workspace mobile-app check:public-env
 
+      - name: Check admin web-only guardrail
+        run: yarn workspace mobile-app check:admin-web-only
+
       - name: Run tests
         run: yarn workspace mobile-app test --ci --runInBand
 

--- a/mobile-app/app/(tabs)/lnf.tsx
+++ b/mobile-app/app/(tabs)/lnf.tsx
@@ -84,18 +84,20 @@ export default function LnfScreen() {
           </Button>
         </View>
 
-        {/* Admin Access Button */}
-        <View style={styles.adminButtonContainer}>
-          <Button
-            mode="text"
-            icon="shield-account"
-            onPress={() => router.push("/admin/login")}
-            style={styles.adminButton}
-            compact
-          >
-            Admin
-          </Button>
-        </View>
+        {/* Admin Access Button — web only; native builds ship a stub admin route */}
+        {Platform.OS === "web" && (
+          <View style={styles.adminButtonContainer}>
+            <Button
+              mode="text"
+              icon="shield-account"
+              onPress={() => router.push("/admin/login")}
+              style={styles.adminButton}
+              compact
+            >
+              Admin
+            </Button>
+          </View>
+        )}
       </View>
     </ThemedView>
   );

--- a/mobile-app/app/(tabs)/lnf.tsx
+++ b/mobile-app/app/(tabs)/lnf.tsx
@@ -94,7 +94,7 @@ export default function LnfScreen() {
               style={styles.adminButton}
               compact
             >
-              Admin
+              {t("admin.title", { defaultValue: "Admin" })}
             </Button>
           </View>
         )}

--- a/mobile-app/app/admin/_layout.tsx
+++ b/mobile-app/app/admin/_layout.tsx
@@ -1,3 +1,10 @@
+// Admin is a WEB-ONLY surface. Every route file in this directory must be a
+// one-line re-export from src/features/admin/<name>, which must have both a
+// .web.tsx real screen and a .tsx stub re-exporting AdminWebOnly — that keeps
+// staff email/password login out of the iOS/Android bundles (Play Data
+// Safety). Do not add screens directly here, and do not use .web.tsx files
+// inside app/ (expo-router bundles them on every platform). Enforced by
+// scripts/check-admin-web-only.js; see DEPLOYMENT_GUIDE.md.
 import { Stack } from "expo-router";
 
 export default function AdminLayout() {

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -16,7 +16,8 @@
     "i18n:scan": "i18next-scanner",
     "test": "jest",
     "check-size": "node scripts/check-bundle-size.js",
-    "check:public-env": "node scripts/check-public-env.js"
+    "check:public-env": "node scripts/check-public-env.js",
+    "check:admin-web-only": "node scripts/check-admin-web-only.js"
   },
   "dependencies": {
     "@hcaptcha/react-native-hcaptcha": "^1.0.2",

--- a/mobile-app/scripts/check-admin-web-only.js
+++ b/mobile-app/scripts/check-admin-web-only.js
@@ -1,0 +1,119 @@
+// Guards the "admin is web-only" invariant (Play Data Safety: store binaries
+// must not bundle the staff email/password login). The failure mode is silent
+// — the first attempt at this split shipped admin code to Android with tests,
+// lint, and typecheck all green — so CI enforces the structure:
+//
+//   1. app/admin/*.tsx (except _layout.tsx) must be one-line re-exports from
+//      src/features/admin/<name>.
+//   2. No platform-suffixed route files (*.web.tsx etc.) may exist under
+//      app/ — expo-router bundles every app/ file on every platform.
+//   3. Every src/features/admin/*.web.tsx needs a sibling .tsx stub that
+//      re-exports AdminWebOnly (what native builds resolve).
+//   4. Nothing may import a features/admin module with an explicit .web
+//      extension (which would drag web code into native bundles).
+//
+// Release-time backstop: `npx expo export --platform android` and grep the
+// bundle for "manage-admin-users" (must be absent). See DEPLOYMENT_GUIDE.md.
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const mobileAppRoot = path.resolve(__dirname, "..");
+const adminRoutesDir = path.join(mobileAppRoot, "app", "admin");
+const adminFeaturesDir = path.join(mobileAppRoot, "src", "features", "admin");
+const appDir = path.join(mobileAppRoot, "app");
+
+const ROUTE_RE_EXPORT_RE =
+  /^export \{ default \} from "\.\.\/\.\.\/src\/features\/admin\/[a-zA-Z0-9-]+";\s*$/;
+const STUB_RE_EXPORT_RE = /^export \{ default \} from "\.\.\/\.\.\/components\/AdminWebOnly";\s*$/;
+const PLATFORM_SUFFIX_RE = /\.(web|ios|android|native)\.[jt]sx?$/;
+
+const failures = [];
+
+function listFiles(dir, recursive = false) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (recursive) out.push(...listFiles(full, true));
+    } else {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function rel(p) {
+  return path.relative(mobileAppRoot, p);
+}
+
+// 1. Route files must be pure re-exports.
+for (const file of listFiles(adminRoutesDir)) {
+  const base = path.basename(file);
+  if (base === "_layout.tsx") continue;
+  const content = fs.readFileSync(file, "utf8").trim();
+  if (!ROUTE_RE_EXPORT_RE.test(content)) {
+    failures.push(
+      `${rel(file)}: admin route files must be a single re-export from src/features/admin ` +
+        `(got ${content.split("\n").length} line(s)). Real screens belong in ` +
+        `src/features/admin/<name>.web.tsx with a .tsx AdminWebOnly stub.`,
+    );
+  }
+}
+
+// 2. No platform-suffixed route files anywhere under app/.
+for (const file of listFiles(appDir, true)) {
+  if (PLATFORM_SUFFIX_RE.test(path.basename(file))) {
+    failures.push(
+      `${rel(file)}: platform-suffixed files are forbidden under app/ — expo-router ` +
+        `bundles every app/ file on every platform, so this does NOT platform-split.`,
+    );
+  }
+}
+
+// 3. Every web screen needs a native stub that resolves to AdminWebOnly.
+for (const file of listFiles(adminFeaturesDir)) {
+  const base = path.basename(file);
+  if (!base.endsWith(".web.tsx")) continue;
+  const stubPath = path.join(adminFeaturesDir, base.replace(".web.tsx", ".tsx"));
+  if (!fs.existsSync(stubPath)) {
+    failures.push(
+      `${rel(file)}: missing native stub ${rel(stubPath)} — without it, native builds ` +
+        `resolve nothing (or worse, the web screen) for this module.`,
+    );
+    continue;
+  }
+  const stubContent = fs.readFileSync(stubPath, "utf8").trim();
+  if (!STUB_RE_EXPORT_RE.test(stubContent)) {
+    failures.push(
+      `${rel(stubPath)}: native admin stubs must only re-export AdminWebOnly; anything ` +
+        `else risks shipping admin code in the store binaries.`,
+    );
+  }
+}
+
+// 4. No explicit .web imports of admin modules from anywhere.
+const scanRoots = [appDir, path.join(mobileAppRoot, "src"), path.join(mobileAppRoot, "components")];
+for (const root of scanRoots) {
+  if (!fs.existsSync(root)) continue;
+  for (const file of listFiles(root, true)) {
+    if (!/\.[jt]sx?$/.test(file)) continue;
+    const content = fs.readFileSync(file, "utf8");
+    if (/features\/admin\/[a-zA-Z0-9-]+\.web/.test(content)) {
+      failures.push(
+        `${rel(file)}: imports a features/admin module with an explicit .web extension, ` +
+          `which would bundle web admin code into native builds.`,
+      );
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Admin web-only guardrail failed:\n");
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log("Admin web-only guardrail passed.");

--- a/mobile-app/src/components/AdminWebOnly.tsx
+++ b/mobile-app/src/components/AdminWebOnly.tsx
@@ -1,32 +1,53 @@
 // Native fallback for the admin routes. The real screens live in
-// app/admin/*.web.tsx, so staff login (and its email/password collection)
-// is bundled only into the web build — the store binaries must stay free
+// src/features/admin/*.web.tsx; Metro resolves these sibling stubs on
+// iOS/Android so staff login (and its email/password collection) is
+// bundled only into the web build — the store binaries must stay free
 // of email collection to match the Play Data Safety declaration.
+//
+// Do NOT put platform forks in app/admin/ itself: expo-router bundles
+// every file under app/ on every platform regardless of .web suffixes
+// (see DEPLOYMENT_GUIDE.md, "Play Data Safety — email collection").
 import React from "react";
-import { StyleSheet, View } from "react-native";
-import { Text } from "react-native-paper";
+import { StyleSheet } from "react-native";
+import { Button } from "react-native-paper";
+import { useRouter } from "expo-router";
 import { useTranslation } from "react-i18next";
+
+import { ThemedView } from "../../components/ThemedView";
+import EmptyState from "./EmptyState";
 
 export default function AdminWebOnly() {
   const { t } = useTranslation();
+  const router = useRouter();
+
+  const goBack = () => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace("/");
+    }
+  };
 
   return (
-    <View style={styles.container}>
-      <Text variant="titleMedium" style={styles.message}>
-        {t("admin.webOnly", "Admin tools are available in the web version of AI Advocate.")}
-      </Text>
-    </View>
+    <ThemedView style={styles.container}>
+      <EmptyState
+        icon="person.crop.circle.badge.exclamationmark"
+        title={t("admin.title", "Admin")}
+        message={t("admin.webOnly", "Admin tools are available in the web version of AI Advocate.")}
+      />
+      <Button mode="text" onPress={goBack} style={styles.backButton}>
+        {t("common.back", "Back")}
+      </Button>
+    </ThemedView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-    padding: 24,
   },
-  message: {
-    textAlign: "center",
+  backButton: {
+    alignSelf: "center",
+    marginBottom: 24,
   },
 });

--- a/mobile-app/src/features/admin/account.web.tsx
+++ b/mobile-app/src/features/admin/account.web.tsx
@@ -122,13 +122,20 @@ export default function AdminAccountScreen() {
   };
 
   const performPasswordChange = async () => {
+    // Session can be invalidated between the mount-time guard and this click
+    const email = session?.user?.email;
+    if (!email) {
+      Toast.show({ type: "error", text1: "Session expired", text2: "Please sign in again" });
+      router.replace("/admin/login");
+      return;
+    }
     setChangingPassword(true);
     try {
       // Only re-auth with password if MFA is NOT enabled
       // If MFA is enabled, we rely on the AAL2 upgrade we just did
       if (!mfaEnabled) {
         const { error: signInError } = await supabase.auth.signInWithPassword({
-          email: session!.user.email!,
+          email,
           password: currentPassword,
         });
 
@@ -250,7 +257,7 @@ export default function AdminAccountScreen() {
       const { data, error } = await supabase.auth.mfa.enroll({
         factorType: "totp",
         issuer: "AIAdvocate",
-        friendlyName: session!.user.email,
+        friendlyName: session?.user?.email ?? "AIAdvocate Admin",
       });
 
       if (error) throw error;

--- a/mobile-app/src/features/admin/bills.web.tsx
+++ b/mobile-app/src/features/admin/bills.web.tsx
@@ -23,12 +23,16 @@ import { ThemedView } from "../../../components/ThemedView";
 // Helper function for audit logging
 const logAdminAction = async (userId: string, action: string, billId?: number, details?: any) => {
   try {
-    await supabase.from("admin_audit_log").insert({
+    // insert() resolves with { error } instead of throwing on DB failures
+    const { error } = await supabase.from("admin_audit_log").insert({
       user_id: userId,
       action,
       bill_id: billId,
       details: details ? JSON.stringify(details) : null,
     });
+    if (error) {
+      console.warn("Failed to log admin action:", error);
+    }
   } catch (err) {
     console.warn("Failed to log admin action:", err);
   }

--- a/mobile-app/src/features/admin/login.web.tsx
+++ b/mobile-app/src/features/admin/login.web.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { View, StyleSheet, KeyboardAvoidingView, Platform } from "react-native";
+import { View, StyleSheet } from "react-native";
 import { Text, TextInput, Button, Card, useTheme } from "react-native-paper";
 import { useRouter } from "expo-router";
 import { supabase } from "../../lib/supabase";
@@ -78,10 +78,7 @@ export default function AdminLoginScreen() {
   };
 
   return (
-    <KeyboardAvoidingView
-      style={[styles.container, { backgroundColor: theme.colors.background }]}
-      behavior={Platform.OS === "ios" ? "padding" : "height"}
-    >
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
       <View style={styles.content}>
         <Card style={styles.card}>
           <Card.Title title="Admin Login" subtitle="Enter your credentials" />
@@ -124,7 +121,7 @@ export default function AdminLoginScreen() {
           </Card.Content>
         </Card>
       </View>
-    </KeyboardAvoidingView>
+    </View>
   );
 }
 

--- a/mobile-app/src/features/admin/users.web.tsx
+++ b/mobile-app/src/features/admin/users.web.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { View, StyleSheet, FlatList, Alert, Platform } from "react-native";
+import { View, StyleSheet, FlatList } from "react-native";
 import {
   Text,
   Button,
@@ -54,7 +54,7 @@ export default function AdminUsersScreen() {
 
       if (error) throw error;
 
-      setAdmins(data.admins);
+      setAdmins(data?.admins ?? []);
     } catch (err: any) {
       console.error("Load admins error:", err);
       if (err.message?.includes("Failed to send a request")) {
@@ -97,26 +97,12 @@ export default function AdminUsersScreen() {
   };
 
   const handleRemoveAdmin = async (userId: string) => {
-    if (Platform.OS === "web") {
-      const confirmed = window.confirm(
-        "Are you sure you want to remove this admin? This will delete their account.",
-      );
-      if (confirmed) {
-        await removeAdmin(userId);
-      }
-    } else {
-      Alert.alert(
-        "Remove Admin",
-        "Are you sure you want to remove this admin? This will delete their account.",
-        [
-          { text: "Cancel", style: "cancel" },
-          {
-            text: "Remove",
-            style: "destructive",
-            onPress: () => removeAdmin(userId),
-          },
-        ],
-      );
+    // Web-only file: window.confirm is always available here.
+    const confirmed = window.confirm(
+      "Are you sure you want to remove this admin? This will delete their account.",
+    );
+    if (confirmed) {
+      await removeAdmin(userId);
     }
   };
 

--- a/mobile-app/src/locales/en.json
+++ b/mobile-app/src/locales/en.json
@@ -1,4 +1,8 @@
 {
+  "admin": {
+    "title": "Admin",
+    "webOnly": "Admin tools are available in the web version of AI Advocate."
+  },
   "bill": {
     "attribution": { "legiscan": "Original text provided by LegiScan" },
     "missing": "Bill Not Found",

--- a/mobile-app/src/locales/es.json
+++ b/mobile-app/src/locales/es.json
@@ -1,4 +1,8 @@
 {
+  "admin": {
+    "title": "Administración",
+    "webOnly": "Las herramientas de administración están disponibles en la versión web de AI Advocate."
+  },
   "bill": {
     "attribution": { "legiscan": "Texto original proporcionado por LegiScan" },
     "missing": "Proyecto no encontrado",

--- a/mobile-app/src/providers/AuthProvider.tsx
+++ b/mobile-app/src/providers/AuthProvider.tsx
@@ -1,6 +1,7 @@
 // mobile-app/src/providers/AuthProvider.tsx
 
 import React, { createContext, useContext, useState, useEffect } from "react";
+import { Platform } from "react-native";
 import { Session } from "@supabase/supabase-js";
 import { supabase } from "../lib/supabase";
 import Toast from "react-native-toast-message";
@@ -37,6 +38,14 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
           // instead of leaving the user with no session forever.
           captureException(error, { context: "auth_initialization_get_session" });
           recoveryError = error;
+        } else if (session && session.user.is_anonymous === false && Platform.OS !== "web") {
+          // Staff email/password sessions belong to the web admin surface
+          // only. A session persisted from a build that still had native
+          // admin login would otherwise keep an email-bearing token on the
+          // device forever (no native sign-out path exists anymore), so
+          // replace it with the anonymous session every public user gets.
+          await supabase.auth.signOut();
+          // fall through to anonymous sign-in below
         } else {
           setSession(session);
           if (session) return;

--- a/mobile-app/src/providers/AuthProvider.tsx
+++ b/mobile-app/src/providers/AuthProvider.tsx
@@ -44,6 +44,12 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
           // admin login would otherwise keep an email-bearing token on the
           // device forever (no native sign-out path exists anymore), so
           // replace it with the anonymous session every public user gets.
+          //
+          // `=== false` (not `!== true`) is deliberate: a session whose user
+          // lacks the is_anonymous flag must be KEPT — signing out an
+          // anonymous user permanently orphans their bookmarks/reactions,
+          // while a missed staff session is only deferred cleanup (the flag
+          // arrives with the next token refresh and this check re-runs).
           await supabase.auth.signOut();
           // fall through to anonymous sign-in below
         } else {


### PR DESCRIPTION
## Summary
Post-merge review of #63 (8 finder angles → verification) surfaced 10 findings; this PR addresses all of them.

### The two #63 misses (highest severity)
- **The LNF tab has a visible "Admin" button on native** — #63's "no visible entry point" assumption was wrong (an earlier grep hit its display cap inside the admin files and masked this). It now renders only on web; store-build users no longer get a dead-end route that advertises the admin surface.
- **Staff email sessions persisted on native had no exit** — both `signOut()` call sites moved into `*.web.tsx`, so a device signed in as admin before 1.6 would refresh an email-bearing token forever. `AuthProvider` now signs out any explicitly non-anonymous session on native (best-effort) and falls through to the standard anonymous sign-in. Sessions without the `is_anonymous` flag are left untouched.

### Deferred Gemini findings, now verified and fixed
- `logAdminAction` reads `insert()`'s `{ error }` — supabase-js resolves rather than throws on DB failures, so RLS-denied audit writes were silently dropped.
- `setAdmins(data?.admins ?? [])` — `functions.invoke` can return `data: null` with `error: null` on empty/non-JSON 2xx bodies.
- `session!.user.email!` race in `account.web.tsx` → guard + redirect; MFA `friendlyName` gets a safe fallback.
- **Refuted, not applied**: optional-chaining on `updatedData` — the `update_bill_summary` RPC raises on zero rows, so the null state is unreachable (verified against the migration).

### Web-only hygiene + UX
- Dead native forks removed from web-only files (`Alert.alert` branch in `users.web.tsx`, `KeyboardAvoidingView`/`Platform` ternary in `login.web.tsx`) — they read as if the screens still ship on native, which muddies Data Safety audits.
- `AdminWebOnly` now reuses the themed `EmptyState` (fixes wrong background in dark mode), gains a Back button (`canGoBack` fallback to home), and — critically — its comment no longer documents the `app/admin/*.web.tsx` approach that provably does *not* platform-split.
- `admin.title`/`admin.webOnly` added to `en.json` **and `es.json`** (AI-drafted Spanish — worth a native-speaker glance).

### Enforcement (the invariant was convention-only)
`scripts/check-admin-web-only.js` + a CI step, modeled on the existing `check-public-env.js` precedent: admin routes must be pure re-exports, no platform-suffixed files under `app/`, every `.web.tsx` screen needs an `AdminWebOnly` stub sibling, no explicit `.web` imports. #63 proved the failure mode is silent (the first attempt shipped admin code to Android with all checks green), so structure is now CI-enforced, plus a warning comment in `app/admin/_layout.tsx` where a dev would add the next screen.

## Verification
- [x] New guard passes; all gates green (`tsc`, ESLint, 13/13 suites / 50/50 tests)
- [x] **Bundle-level re-check**: exported the Android Hermes bundle after these changes — `manage-admin-users`, `admin_audit_log`, `app_admins`, and sign-in strings all still absent
- [x] Locale JSONs parse; ES fallback verified structurally


---
_Generated by [Claude Code](https://claude.ai/code/session_01EV2sP8kD3o3bg2zdLiEzRD)_