### PR TITLE
chore: bump app version to 1.7.0 for the clean-binary resubmission

### DIFF
--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -3,7 +3,7 @@
     "name": "AI Advocate",
     "slug": "ai-advocate",
     "owner": "joela510",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "mobileapp",

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-app",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {


### PR DESCRIPTION
## Summary
Bumps the user-facing version to **1.7.0** (`app.json` + workspace `package.json`) so the next Play submission is unambiguously the clean binary — no admin code, no Firebase SDKs.

Verified while making the change, using the failed build's fingerprint (`1b2ee134…`, built from `cf8346f`):
- **Locally-computed fingerprint with dummy env values matches the EAS build's exactly** — end-to-end confirmation that `fingerprint.config.js`'s env-independence works in practice, not just in theory.
- **Post-bump fingerprint is unchanged** — the `ExpoConfigVersions` skip does its job, so version bumps no longer re-segment OTA update targeting.

Reminder from the investigation: since `cf8346f` was already clean, the recurring Data Safety flag is almost certainly evaluated against the *old* binaries still active (the live production release genuinely contains the pre-split email login). The unblock is: temporarily declare email collection (true for the live binary) → get the 1.7.0 build approved and promoted to Production → revert the declaration once only clean binaries remain active.

## Test plan
- [x] Fingerprint identical pre/post bump (`1b2ee1344992c0d1f7821b9c071337d84969bee3`)
- [x] typecheck clean, 50/50 tests pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01EV2sP8kD3o3bg2zdLiEzRD)_