### PR TITLE
fix(android): disable expo-updates (bisect step 3)

### DIFF
--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -72,6 +72,7 @@
       }
     },
     "updates": {
+      "enabled": false,
       "url": "https://u.expo.dev/2815e517-2761-4f1b-a1d9-57dc978c3b0c"
     },
     "runtimeVersion": {


### PR DESCRIPTION
## Summary
New evidence from the credentialed diagnostics this session:

- **Sentry: zero sessions from any mobile release, ever.** JS has never executed on any device, either platform, any build of this era — including vc 11 (e2e-off + failsafe) on Google's pre-launch farm. Edge-to-edge is exonerated; the failure is in the **pre-JS native layer shared by both platforms**.
- **Play API: vc 11 is live on production** (plus a stray draft that caused the promote errors); the iOS sibling crashes at launch per App Review. One cross-platform mechanism fits everything: **expo-updates initializes before JS on both platforms** — a failing init crashes iOS at launch and hangs Android on the splash.
- **AAB forensics (vc 11)**: the embedded update is internally consistent (fingerprint asset matches the `file:fingerprint` sentinel; 4.3MB Hermes bundle present) — so the suspect behavior is runtime init, not packaging.

This PR sets `updates.enabled: false` — EXUpdates goes dormant and the binary loads its embedded bundle directly. If the resulting build launches, expo-updates is convicted; OTA stays off until re-enabled deliberately (optionally with a static `runtimeVersion`) as its own change.

The verdict loop is now fully autonomous: I trigger the EAS build, submit it to the Play internal track via API, Google's pre-launch farm runs it, and **Sentry sessions appearing = JS runs** — readable by me directly, no device needed.

## Test plan
- [x] app.json valid; typecheck; 50/50 tests
- [ ] After merge: I build via EAS, submit to internal via Play API, and watch Sentry for first-ever mobile sessions


---
_Generated by [Claude Code](https://claude.ai/code/session_01EV2sP8kD3o3bg2zdLiEzRD)_