### PR TITLE
feat(eas): add internal-apk profile for sideloadable diagnostic builds

### DIFF
--- a/mobile-app/eas.json
+++ b/mobile-app/eas.json
@@ -40,6 +40,15 @@
       "android": {
         "buildType": "app-bundle"
       }
+    },
+    "internal-apk": {
+      "extends": "production",
+      "distribution": "internal",
+      "environment": "production",
+      "autoIncrement": false,
+      "android": {
+        "buildType": "apk"
+      }
     }
   },
   "submit": {


### PR DESCRIPTION
## Summary
On-device testing hit a wall: EAS production artifacts are AABs, which **cannot be sideloaded** — only Play can serve installs from them. This adds an `internal-apk` build profile that emits a signed, directly-installable APK from the exact same configuration:

- `extends: production` — same env vars, channel, and credentials
- `environment: "production"` pinned explicitly — internal-distribution profiles otherwise default to the preview environment, where the `EXPO_PUBLIC_*` interpolations would resolve empty
- `autoIncrement: false` — diagnostic builds don't consume version codes
- `buildType: apk`, `distribution: internal` — the artifact link from expo.dev is downloadable straight onto a device

First use: a sideloadable twin of the vc 12 updates-disabled bisect build, so the splash verdict doesn't depend on Play internal-track enrollment.

## Test plan
- [x] eas.json valid JSON
- [ ] After merge: trigger `eas build -p android --profile internal-apk`, sideload the artifact, observe the splash


---
_Generated by [Claude Code](https://claude.ai/code/session_01EV2sP8kD3o3bg2zdLiEzRD)_