### PR TITLE
fix(ui): stop double-counting safe-area insets under edge-to-edge

### DIFF
--- a/mobile-app/app/(tabs)/active.tsx
+++ b/mobile-app/app/(tabs)/active.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from "react";
 import { StyleSheet, FlatList, View } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "react-native-paper";
 import BillComponent from "../../src/components/Bill";
@@ -34,7 +33,6 @@ export default function ActiveScreen() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { t } = useTranslation();
-  const insets = useSafeAreaInsets();
   const theme = useTheme();
   const colors = theme.colors as unknown as Record<string, string>;
 
@@ -105,14 +103,14 @@ export default function ActiveScreen() {
         data={bills}
         keyExtractor={(item) => item.id.toString()}
         renderItem={({ item }) => <BillComponent bill={item} />}
-        contentContainerStyle={{ paddingBottom: insets.bottom + 40 }}
+        contentContainerStyle={{ paddingBottom: 40 }}
         showsVerticalScrollIndicator={false}
       />
     );
   };
 
   return (
-    <ThemedView style={[styles.container, { paddingTop: insets.top + 8 }]}>
+    <ThemedView style={[styles.container, { paddingTop: 8 }]}>
       <View
         style={[
           styles.header,
@@ -125,7 +123,7 @@ export default function ActiveScreen() {
       >
         <ThemedText type="title">{t("tabs.active.title", "Active Bills")}</ThemedText>
       </View>
-      <View style={[styles.content, { paddingBottom: insets.bottom + 12 }]}>{renderContent()}</View>
+      <View style={[styles.content, { paddingBottom: 12 }]}>{renderContent()}</View>
     </ThemedView>
   );
 }

--- a/mobile-app/app/(tabs)/advocacy.tsx
+++ b/mobile-app/app/(tabs)/advocacy.tsx
@@ -2,7 +2,6 @@
 import React, { useEffect, useState } from "react";
 import { ScrollView, StyleSheet, View } from "react-native";
 import { Stack } from "expo-router";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { ThemedView } from "../../components/ThemedView";
 import { ThemedText } from "../../components/ThemedText";
@@ -13,7 +12,6 @@ import type { Bill } from "../../src/components/Bill";
 
 export default function AdvocacyScreen() {
   const { t } = useTranslation();
-  const insets = useSafeAreaInsets();
   const theme = useTheme();
   const colors = theme.colors as unknown as Record<string, string>;
 
@@ -50,8 +48,8 @@ export default function AdvocacyScreen() {
         contentContainerStyle={[
           styles.scrollContent,
           {
-            paddingTop: insets.top + 8,
-            paddingBottom: insets.bottom + 16,
+            paddingTop: 8,
+            paddingBottom: 16,
             paddingHorizontal: 16,
           },
         ]}

--- a/mobile-app/app/(tabs)/index.tsx
+++ b/mobile-app/app/(tabs)/index.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useMemo, useCallback, useRef, useTransition } from "react";
 import { StyleSheet, FlatList, View } from "react-native";
 import { Searchbar, SegmentedButtons, useTheme } from "react-native-paper";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { useLocalSearchParams, useRouter, usePathname, type Href } from "expo-router";
 import { keepPreviousData, useQuery, type UseQueryOptions } from "@tanstack/react-query";
@@ -119,7 +118,6 @@ export default function BillsHomeScreen() {
   const [sessionFilter, setSessionFilter] = useState<string>(SESSION_ALL);
   const [availableSessions, setAvailableSessions] = useState<string[]>([]);
   const [translations, setTranslations] = useState<Record<number, TranslationPatch>>({});
-  const insets = useSafeAreaInsets();
   const theme = useTheme();
   const colors = theme.colors as unknown as Record<string, string>;
   const listRef = useRef<FlatList<Bill>>(null);
@@ -390,7 +388,7 @@ export default function BillsHomeScreen() {
           renderItem={() => <BillSkeleton />}
           keyExtractor={(_, index) => `skeleton-${index}`}
           scrollEnabled={false}
-          contentContainerStyle={{ paddingBottom: insets.bottom + 40 }}
+          contentContainerStyle={{ paddingBottom: 40 }}
         />
       );
     }
@@ -428,14 +426,14 @@ export default function BillsHomeScreen() {
         data={displayBills}
         keyExtractor={(item) => item.id.toString()}
         renderItem={renderBillItem}
-        contentContainerStyle={{ paddingBottom: insets.bottom + 40 }}
+        contentContainerStyle={{ paddingBottom: 40 }}
         showsVerticalScrollIndicator={false}
       />
     );
   };
 
   return (
-    <ThemedView style={[styles.container, { paddingTop: insets.top + 8 }]}>
+    <ThemedView style={[styles.container, { paddingTop: 8 }]}>
       <View
         style={[
           styles.header,
@@ -473,7 +471,7 @@ export default function BillsHomeScreen() {
           />
         )}
       </View>
-      <View style={[styles.content, { paddingBottom: insets.bottom + 12 }]}>{renderContent()}</View>
+      <View style={[styles.content, { paddingBottom: 12 }]}>{renderContent()}</View>
     </ThemedView>
   );
 }

--- a/mobile-app/app/(tabs)/lnf.tsx
+++ b/mobile-app/app/(tabs)/lnf.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import { StyleSheet, View, Platform, Linking, Pressable } from "react-native";
 import { Stack, useRouter } from "expo-router";
 import { useTranslation } from "react-i18next";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { WebView } from "react-native-webview";
 import { ThemedView } from "../../components/ThemedView";
 import { ThemedText } from "../../components/ThemedText";
@@ -26,7 +25,6 @@ async function openExternalUrl(url: string): Promise<void> {
 
 export default function LnfScreen() {
   const { t } = useTranslation();
-  const insets = useSafeAreaInsets();
   const router = useRouter();
 
   return (
@@ -34,16 +32,10 @@ export default function LnfScreen() {
       <Stack.Screen
         options={{ title: t("tabs.lnf", { defaultValue: "LNF" }), headerShown: false }}
       />
-      {/* Apply safe-area padding for top/bottom; horizontal padding only on web */}
-      <View
-        style={[
-          styles.content,
-          {
-            paddingTop: insets.top,
-            paddingBottom: insets.bottom,
-          },
-        ]}
-      >
+      {/* Safe-area insets are consumed once by the scaffold (HeaderBanner /
+          FooterNav in app/_layout.tsx); re-applying them here would double the
+          padding. Horizontal padding only on web. */}
+      <View style={styles.content}>
         {Platform.OS === "web" ? (
           <Card mode="elevated" style={styles.heroCard}>
             <Pressable onPress={() => openExternalUrl(FEED_URL)} style={{ flex: 1 }}>

--- a/mobile-app/app/(tabs)/saved.tsx
+++ b/mobile-app/app/(tabs)/saved.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { StyleSheet, FlatList, View, RefreshControl } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useFocusEffect, Stack } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "react-native-paper";
@@ -14,7 +13,6 @@ import { useAuth } from "../../src/providers/AuthProvider";
 
 export default function SavedBillsScreen() {
   const { t } = useTranslation();
-  const insets = useSafeAreaInsets();
   const { session } = useAuth();
   const theme = useTheme();
   const colors = theme.colors as unknown as Record<string, string>;
@@ -119,15 +117,15 @@ export default function SavedBillsScreen() {
         data={bills}
         keyExtractor={(b) => String((b as any).id)}
         renderItem={({ item }) => <BillComponent bill={item} />}
-        contentContainerStyle={{ paddingBottom: insets.bottom + 16 }}
+        contentContainerStyle={{ paddingBottom: 16 }}
         showsVerticalScrollIndicator={false}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
       />
     );
-  }, [loading, bills, insets.bottom, refreshing, onRefresh, t]);
+  }, [loading, bills, refreshing, onRefresh, t]);
 
   return (
-    <ThemedView style={[styles.container, { paddingTop: insets.top + 8, paddingHorizontal: 16 }]}>
+    <ThemedView style={[styles.container, { paddingTop: 8, paddingHorizontal: 16 }]}>
       <Stack.Screen
         options={{ title: t("tabs.saved", { defaultValue: "Saved" }), headerShown: false }}
       />

--- a/mobile-app/app/bill/[id].tsx
+++ b/mobile-app/app/bill/[id].tsx
@@ -9,7 +9,6 @@ import {
   Card,
   ActivityIndicator as PaperActivityIndicator,
 } from "react-native-paper";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import Toast from "react-native-toast-message";
 
@@ -39,7 +38,6 @@ export default function BillDetailsScreen() {
   const { session } = useAuth();
   const { t, i18n } = useTranslation();
   const theme = useTheme();
-  const insets = useSafeAreaInsets();
 
   const [bill, setBill] = useState<Bill | null>(null);
   const [translatedContent, setTranslatedContent] = useState<TranslatedContent | null>(null);
@@ -178,7 +176,7 @@ export default function BillDetailsScreen() {
     <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
       <ScrollView
         style={[styles.scrollView]}
-        contentContainerStyle={{ paddingBottom: insets.bottom }}
+        contentContainerStyle={{ paddingBottom: 16 }}
         showsVerticalScrollIndicator={false}
       >
         <View style={styles.container}>

--- a/mobile-app/app/legislator/[id].tsx
+++ b/mobile-app/app/legislator/[id].tsx
@@ -2,7 +2,6 @@
 import { useLocalSearchParams, useRouter, Stack } from "expo-router";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { View, StyleSheet, ScrollView, Linking } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { Card, Text, Button, ActivityIndicator, useTheme } from "react-native-paper";
 import { supabase } from "../../src/lib/supabase";
@@ -63,7 +62,6 @@ export default function LegislatorScreen() {
   const originTabParam = Array.isArray(params.originTab) ? params.originTab[0] : params.originTab;
   const originTab: "bills" | "advocacy" = originTabParam === "bills" ? "bills" : "advocacy";
   const router = useRouter();
-  const insets = useSafeAreaInsets();
   const { t } = useTranslation();
   const theme = useTheme();
 
@@ -294,8 +292,6 @@ export default function LegislatorScreen() {
         style={[
           styles.center,
           {
-            paddingTop: insets.top,
-            paddingBottom: insets.bottom,
             backgroundColor: theme.colors.background,
           },
         ]}
@@ -321,8 +317,6 @@ export default function LegislatorScreen() {
         style={[
           styles.errorContainer,
           {
-            paddingTop: insets.top,
-            paddingBottom: insets.bottom,
             backgroundColor: theme.colors.background,
           },
         ]}
@@ -351,8 +345,6 @@ export default function LegislatorScreen() {
       style={[
         styles.screen,
         {
-          paddingTop: insets.top,
-          paddingBottom: insets.bottom,
           backgroundColor: theme.colors.background,
         },
       ]}


### PR DESCRIPTION
## The bug

The app scaffold already consumes safe-area insets **exactly once** — `HeaderBanner` applies `insets.top + 24`, `FooterNav` applies `Math.max(bottom, 12)` — and every route renders *between* them inside `mainContent`. Seven screens then applied `insets.top`/`insets.bottom` again.

This was invisible until Batch A (#73). Without edge-to-edge, Android's `react-native-safe-area-context` computes insets relative to the RN root view, which already began below the status bar — so both values were `0` and the duplication cost nothing. With edge-to-edge on they are real, and the duplication surfaces as a blank band under the header and a dead scroll gap above the footer on every screen. `legislator/[id].tsx` applied the pair to three separate containers, so it triples up.

iOS has reported non-zero insets all along, so this also removes long-standing double padding there.

## The fix

Remove the redundant per-screen insets while keeping each screen's *intentional* spacing:

| Before | After |
|---|---|
| `paddingTop: insets.top + 8` | `paddingTop: 8` |
| `paddingBottom: insets.bottom + 40` | `paddingBottom: 40` |
| `paddingTop: insets.top` (bare) | removed |
| `paddingBottom: insets.bottom` (bare, `bill/[id].tsx`) | `paddingBottom: 16` — keeps a scroll gutter |

Then drop the now-unused `useSafeAreaInsets()` calls and imports (7 files), and the stale `insets.bottom` entry in `saved.tsx`'s `useMemo` dependency array.

**Deliberately untouched:** `Toast topOffset={Math.max(40, insets.top + 16)}` in `_layout.tsx`. That toast renders as a sibling of the scaffold, not inside `mainContent`, so it is measured from the root view and its inset use is correct — it is the one place that *should* consume `insets.top`.

## Scope note

This is layout-only — no native config, no plugin, no `app.json`. The runtime fingerprint is unchanged, so this is OTA-shippable to any binary carrying Batch A/B once one is live.

## Verification

- `tsc --noEmit` clean · eslint 0 errors (3 pre-existing `i18next/no-literal-string` warnings, untouched) · `jest` 15/15 suites, 59/59 tests.
- Net −26 lines across 7 files.
- **Not device-verified** — the visual result needs a look on-device. It can ride the next diagnostic APK or the vc14 internal-track build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EV2sP8kD3o3bg2zdLiEzRD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EV2sP8kD3o3bg2zdLiEzRD)_