### PR TITLE
chore(release): bump version to 1.8.0

### DIFF
--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -3,7 +3,7 @@
     "name": "AI Advocate",
     "slug": "ai-advocate",
     "owner": "joela510",
-    "version": "1.7.0",
+    "version": "1.8.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "mobileapp",

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-app",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Why

The repo's release rule (README §Release Process, `DEPLOYMENT_GUIDE.md`) says to bump `expo.version` in `app.json` and keep `package.json`'s `version` in sync for each release. This is a release.

It also matters practically here: **vc13 (1.7.0) is the build currently live in production**, and this release is materially different from it — OTA restored, edge-to-edge on, R8 + resource shrinking on, and the safe-area inset double-count fixed. Shipping it as another `1.7.0` would leave Play release notes, Sentry release grouping (the SDK derives release from `bundleId@version+build`, so only the build counter would differ), and "what version are you on?" support triage unable to distinguish the fixed build from the broken one.

## OTA impact: none

`fingerprint.config.js` sets `sourceSkips: ["ExpoConfigVersions", ...]`, so the marketing version is excluded from the runtime fingerprint — this bump does not re-segment update targeting.

## What ships in 1.8.0

| | |
|---|---|
| #72 | Root-cause fix for the `eas.json` `${}` placeholder incident + boot hardening |
| #73 | Batch A — expo-updates, edge-to-edge, Sentry AGP restored; vestigial iOS static frameworks dropped |
| #74 | Batch B — R8/Proguard + resource shrinking (**device-verified**, 6.8 MB / 7.5% smaller) |
| #76 | Safe-area inset double-count fix |

Version-only change; no code, config, or native surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EV2sP8kD3o3bg2zdLiEzRD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EV2sP8kD3o3bg2zdLiEzRD)_