### PR TITLE
fix(ingestion): restore bill discovery, add API guardrails, repair votes-daily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Check admin web-only guardrail
         run: yarn workspace mobile-app check:admin-web-only
 
+      - name: Check external API usage guardrail
+        run: yarn workspace mobile-app check:external-api
+
       - name: Run tests
         run: yarn workspace mobile-app test --ci --runInBand
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ When instructions or facts conflict, use this priority order:
 4. Repo-local docs and config:
    - `README.md`
    - `CONTRIBUTING.md`
-   - `docs/`
+   - `docs/` (`docs/external-api-policy.md` is binding for any LegiScan/OpenStates work)
    - `.github/workflows/`
    - `supabase/`
    - package scripts
@@ -101,6 +101,25 @@ For destructive or high-risk DB work, provide a plan first:
 * known risks
 
 ## 5. Supabase Edge Function and scheduler rules
+
+### External API access — read `docs/external-api-policy.md` first
+
+Before touching any code path that calls LegiScan or OpenStates, read
+`docs/external-api-policy.md`. It is binding, and CI enforces the mechanical
+parts via `yarn workspace mobile-app check:external-api`.
+
+The non-negotiables:
+
+- The LegiScan key is single and irreplaceable. It was locked once already
+  (2026-07-26) for issuing 23 requests in ~20 seconds. **Never register a
+  replacement key** — restoration goes through api@legiscan.com only.
+- Every LegiScan request goes through `public.reserve_legiscan_api_call`, and
+  is skipped when the reservation is not `allowed`.
+- Rate floors: ≥ 1000 ms between calls, ≤ 6 calls per invocation, never
+  concurrent, and abort the whole sweep on the first `status: "ERROR"`.
+- Never point a test loop or ad-hoc script at production LegiScan. Use
+  `dry_run` with a reduced phrase/page set.
+- Prefer free sources (leginfo scraping) over API quota.
 
 This project uses scheduled database wrappers and Edge Functions for ingestion. Treat the database-to-Edge path as a chain:
 

--- a/docs/external-api-policy.md
+++ b/docs/external-api-policy.md
@@ -1,0 +1,147 @@
+# External API usage policy
+
+Binding rules for every call this project makes to a third-party legislative
+data provider. **LegiScan and OpenStates access is single-key and
+irreplaceable**: losing a key takes bill ingestion offline entirely, and
+LegiScan explicitly forbids replacing a locked key. Treat these rules the same
+way as the RLS and secret-handling rules in `AGENTS.md`.
+
+CI enforces the mechanical parts via
+`yarn workspace mobile-app check:external-api`
+(`mobile-app/scripts/check-external-api-usage.js`). The rest is on reviewers.
+
+---
+
+## 1. Incident record — read this before changing any call site
+
+**2026-07-26: the LegiScan API key was locked.**
+
+A discovery sweep issued **23 `getSearch` calls in roughly 20 seconds** while
+being tested. LegiScan's response:
+
+> API key has been locked because of a violation of the Terms of Service
+> abusing public services, please contact api@legiscan.com to restore access.
+> Creating additional API keys will result in permanent suspension.
+
+The per-call guardrails (`reserve_legiscan_api_call`) were all satisfied — each
+call was individually within its cooldown and quota. What tripped the lock was
+**request rate**, which nothing in the system limited at the time. That is why
+§3 exists as a separate rule from §2.
+
+**Never register a replacement key.** Restoration goes through
+api@legiscan.com only.
+
+---
+
+## 2. LegiScan: published limits
+
+From the LegiScan API User Manual (`https://api.legiscan.com/dl/`). These are
+the provider's own numbers — do not "optimise" past them.
+
+- **Public service keys have a monthly limit of 30,000 queries.**
+- Each operation has a documented minimum refresh interval. Requesting more
+  often than this **still spends a query** and returns unchanged cached data,
+  so exceeding it is pure waste:
+
+  | Operation | Documented frequency |
+  | --- | --- |
+  | `getDatasetList` | Weekly |
+  | `getDataset` | Weekly |
+  | `getSearch` / `getSearchRaw` | 1 hour |
+  | `getMasterList` / `getMasterListRaw` | 1 hour |
+  | `getBill` | 3 hours |
+  | `getBillText` | Static (fetch once, cache forever) |
+  | `getRollCall` / `getAmendment` / `getSupplement` | Static |
+  | `getPerson` / `getSessionPeople` | Weekly |
+
+  The manual's own guidance: *"In practice most use cases can be satisfied with
+  daily updates."*
+
+## 3. LegiScan: self-imposed rate limits
+
+LegiScan does not publish a requests-per-second ceiling, but its Terms of
+Service prohibit "abusing public services" and enforcement is automated and
+immediate (§1). These floors are therefore mandatory and are CI-checked:
+
+- **≥ 1000 ms between consecutive LegiScan calls** from a single invocation.
+  Current default is 1500 ms.
+- **≤ 6 LegiScan calls per function invocation.** Work that needs more is spread
+  across days by the per-resource cooldown, not crammed into one run.
+- **No concurrent LegiScan calls.** Never issue LegiScan requests inside
+  `Promise.all`, `runConcurrent`, or any parallel map. Sequential only.
+- **Abort the whole sweep on the first API-level error.** A LegiScan response of
+  `status: "ERROR"` (locked key, exhausted quota, malformed query) will repeat
+  for every subsequent call. Stop; do not continue to the next item.
+- **Never run an ad-hoc burst against production.** Test loops with `dry_run`
+  plus a reduced phrase/page set, or against recorded fixtures.
+
+## 4. LegiScan: mandatory metering
+
+- **Every LegiScan request must be reserved first** through
+  `public.reserve_legiscan_api_call(p_endpoint, p_resource_key,
+  p_cooldown_seconds, p_daily_limit, p_monthly_limit)`. If the reservation is
+  not `allowed`, the call **must not** be made. CI fails any file that fetches
+  `api.legiscan.com` without referencing this RPC.
+- Reservation cooldowns must be **at or above** the §2 documented frequency for
+  that operation.
+- The reservation is what writes `public.legiscan_api_call_log`, which is the
+  only record of quota consumption. A call made outside it is invisible to the
+  daily/monthly budget and corrupts the accounting.
+- Diagnostics count too. Calling LegiScan directly from SQL/`pg_net` bypasses
+  the log; if you must, record it and say so.
+
+## 5. Prefer free sources over quota
+
+Bill text and status are available from
+`leginfo.legislature.ca.gov` at no API cost. The ingestion pipeline uses
+leginfo scraping as the primary text source and LegiScan `getBillText` only as
+a fallback. When adding a feature, ask whether leginfo can answer it before
+spending quota.
+
+Leginfo is a public government site, not an API — keep requests sequential and
+spaced (≥ 250 ms), and send a real `User-Agent`.
+
+## 6. OpenStates
+
+- Endpoint: `https://openstates.org/graphql` (GraphQL v1), key on `X-API-KEY`.
+- **The schema is not stable and is not versioned.** As of 2026-07-26 the root
+  query type exposes only: `jurisdictions`, `jurisdiction`, `people`, `person`,
+  `organization`, `bill`, `bills`. There is **no** `voteEvents` root field and
+  **no** `DateTime` scalar — `updatedSince` is a `String`. A query written
+  against a schema that no longer exists returns HTTP 400.
+- Because of that, **always surface the GraphQL error body on a non-2xx
+  response.** A bare `OpenStates request failed (400)` hid a completely broken
+  nightly job for months. See `src/lib/openstatesClient.ts`.
+- Keep `batchSize` small (≤ 5) and never widen it to "catch up" faster.
+- Verify any schema assumption by introspection before shipping, not by
+  inference from another query that happens to work.
+
+## 7. Adding a new external call site
+
+New files that talk to LegiScan or OpenStates must be added to the allowlist in
+`mobile-app/scripts/check-external-api-usage.js`. This is deliberate friction:
+it forces a reviewer to confirm the call is metered, throttled and sequential
+before it can reach production.
+
+## 8. Tunable knobs
+
+All rate-related behaviour in `supabase/functions/bulk-import-dataset` is
+env-configurable, so an incident can be contained without a redeploy:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `BULK_IMPORT_SEARCH_DISCOVERY` | `true` | Kill switch for the full-text sweep |
+| `LEGISCAN_SEARCH_DELAY_MS` | `1500` | Gap between LegiScan search calls |
+| `LEGISCAN_SEARCH_MAX_CALLS_PER_RUN` | `6` | Hard cap per invocation |
+| `LEGISCAN_SEARCH_COOLDOWN_SECONDS` | `72000` | Per (phrase, page) cooldown |
+| `LEGISCAN_DAILY_QUERY_LIMIT` | `900` | Daily budget ceiling |
+| `LEGISCAN_MONTHLY_QUERY_LIMIT` | `25000` | Monthly budget ceiling (below the 30k limit) |
+| `BULK_IMPORT_DATASET_PASS` | `true` | Kill switch for the dataset download pass |
+| `BULK_IMPORT_VERIFY_PER_RUN` | `8` | Leginfo verifications per invocation |
+
+To stop **all** LegiScan traffic immediately without a deploy, disable the
+`daily-bill-sync` cron job:
+
+```sql
+select cron.alter_job((select jobid from cron.job where jobname = 'daily-bill-sync'), active := false);
+```

--- a/docs/external-api-policy.md
+++ b/docs/external-api-policy.md
@@ -67,8 +67,19 @@ immediate (§1). These floors are therefore mandatory and are CI-checked:
   Current default is 1500 ms.
 - **≤ 6 LegiScan calls per function invocation.** Work that needs more is spread
   across days by the per-resource cooldown, not crammed into one run.
-- **No concurrent LegiScan calls.** Never issue LegiScan requests inside
-  `Promise.all`, `runConcurrent`, or any parallel map. Sequential only.
+- **No concurrent LegiScan calls within an invocation.** Never issue LegiScan
+  requests inside `Promise.all`, `runConcurrent`, or any parallel map.
+  Sequential only.
+- **Known gap — cross-invocation concurrency is not enforced.**
+  `invoke_full_legislative_refresh` enqueues five `sync-updated-bills`
+  invocations through `pg_net`, which run in parallel. With
+  `SYNC_USE_LEGISCAN=true` those five workers can call LegiScan simultaneously,
+  and nothing in the code serialises them: `reserve_legiscan_api_call` bounds
+  per-resource cooldowns and daily/monthly totals, not instantaneous rate.
+  Today this is latent because `SYNC_USE_LEGISCAN` defaults to `false` and that
+  path scrapes leginfo instead. **Before enabling it**, either reduce the fan-out
+  or add a shared rate gate. The same caveat applies to leginfo: five parallel
+  workers plus the verification pass can exceed the ≥250 ms spacing in §5.
 - **Abort the whole sweep on the first API-level error.** A LegiScan response of
   `status: "ERROR"` (locked key, exhausted quota, malformed query) will repeat
   for every subsequent call. Stop; do not continue to the next item.

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -17,7 +17,8 @@
     "test": "jest",
     "check-size": "node scripts/check-bundle-size.js",
     "check:public-env": "node scripts/check-public-env.js --self-test && node scripts/check-public-env.js",
-    "check:admin-web-only": "node scripts/check-admin-web-only.js"
+    "check:admin-web-only": "node scripts/check-admin-web-only.js",
+    "check:external-api": "node scripts/check-external-api-usage.js"
   },
   "dependencies": {
     "@hcaptcha/react-native-hcaptcha": "^1.0.2",

--- a/mobile-app/scripts/check-external-api-usage.js
+++ b/mobile-app/scripts/check-external-api-usage.js
@@ -36,8 +36,10 @@ const OPENSTATES_ALLOWLIST = [
   "scripts/backfill-votes.mjs",
 ];
 
-// Directories that may contain server-side external calls.
-const SCAN_ROOTS = ["supabase/functions", "src", "scripts"];
+// Everywhere a provider call could plausibly be added. `mobile-app` is included
+// deliberately: a provider call from the client would also ship the API key to
+// end users, so it must never appear there without review.
+const SCAN_ROOTS = ["supabase/functions", "src", "scripts", "mobile-app"];
 
 const LEGISCAN_HOST_RE = /api\.legiscan\.com/;
 const OPENSTATES_HOST_RE = /openstates\.org\/graphql/;
@@ -62,6 +64,10 @@ const THROTTLE_FLOORS = [
 
 const failures = [];
 
+// This script necessarily contains the host patterns it searches for, so it
+// would otherwise flag itself.
+const SELF_PATH = path.resolve(__filename);
+
 function listFiles(dir) {
   const out = [];
   if (!fs.existsSync(dir)) return out;
@@ -69,7 +75,12 @@ function listFiles(dir) {
     if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) out.push(...listFiles(full));
-    else if (/\.(ts|tsx|js|mjs|py|sh)$/.test(entry.name)) out.push(full);
+    else if (
+      /\.(ts|tsx|js|mjs|py|sh)$/.test(entry.name) &&
+      path.resolve(full) !== SELF_PATH
+    ) {
+      out.push(full);
+    }
   }
   return out;
 }

--- a/mobile-app/scripts/check-external-api-usage.js
+++ b/mobile-app/scripts/check-external-api-usage.js
@@ -1,0 +1,166 @@
+// Guards the external-API rules in docs/external-api-policy.md.
+//
+// Context: on 2026-07-26 the LegiScan API key was locked for ToS abuse after a
+// sweep issued 23 getSearch calls in ~20 seconds. Every individual call passed
+// the reserve_legiscan_api_call cooldown/quota check — nothing in the system
+// limited *rate*, and nothing stopped a new file from calling LegiScan without
+// metering at all. LegiScan forbids registering a replacement key, so this
+// failure mode is close to unrecoverable and is worth failing CI over.
+//
+// Checks:
+//   1. Only allowlisted files may contact LegiScan or OpenStates at all.
+//      Adding a call site is deliberate friction: a reviewer must confirm it is
+//      metered, throttled and sequential.
+//   2. Any file that fetches api.legiscan.com must route through the
+//      reserve_legiscan_api_call RPC (the only thing that records quota use).
+//   3. LegiScan throttle defaults must stay at or above the policy floors.
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+// Files permitted to contact each provider. Keep this list short; see
+// docs/external-api-policy.md §7 before adding to it.
+const LEGISCAN_ALLOWLIST = [
+  "supabase/functions/bulk-import-dataset/index.ts",
+  "supabase/functions/sync-updated-bills/index.ts",
+];
+
+const OPENSTATES_ALLOWLIST = [
+  "src/lib/openstatesClient.ts",
+  // Operator-run one-off backfills, never on a schedule. They predate the
+  // shared client; if either is ever automated, move it onto openstatesClient
+  // first so retries and error reporting are consistent.
+  "scripts/backfill-openstates-ids.mjs",
+  "scripts/backfill-votes.mjs",
+];
+
+// Directories that may contain server-side external calls.
+const SCAN_ROOTS = ["supabase/functions", "src", "scripts"];
+
+const LEGISCAN_HOST_RE = /api\.legiscan\.com/;
+const OPENSTATES_HOST_RE = /openstates\.org\/graphql/;
+const RESERVE_RPC_RE = /reserve_legiscan_api_call/;
+
+// Policy floors from docs/external-api-policy.md §2-§3.
+const THROTTLE_FLOORS = [
+  {
+    file: "supabase/functions/bulk-import-dataset/index.ts",
+    constant: "DEFAULT_SEARCH_DELAY_MS",
+    min: 1000,
+    unit: "ms between LegiScan calls",
+  },
+  {
+    file: "supabase/functions/bulk-import-dataset/index.ts",
+    constant: "DEFAULT_SEARCH_MAX_CALLS_PER_RUN",
+    min: null,
+    max: 6,
+    unit: "LegiScan calls per invocation",
+  },
+];
+
+const failures = [];
+
+function listFiles(dir) {
+  const out = [];
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...listFiles(full));
+    else if (/\.(ts|tsx|js|mjs|py|sh)$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+function rel(p) {
+  return path.relative(repoRoot, p).split(path.sep).join("/");
+}
+
+/** Read `const NAME = 1_500;` style declarations, tolerating numeric separators. */
+function readNumericConstant(source, name) {
+  const match = source.match(
+    new RegExp(`const\\s+${name}\\s*=\\s*([0-9_]+)\\s*;`),
+  );
+  if (!match) return null;
+  return Number(match[1].replace(/_/g, ""));
+}
+
+const files = SCAN_ROOTS.flatMap((root) => listFiles(path.join(repoRoot, root)));
+
+// 1 + 2. Call-site allowlist and mandatory metering.
+for (const file of files) {
+  const relPath = rel(file);
+  const source = fs.readFileSync(file, "utf8");
+
+  if (LEGISCAN_HOST_RE.test(source)) {
+    if (!LEGISCAN_ALLOWLIST.includes(relPath)) {
+      failures.push(
+        `${relPath}: contacts api.legiscan.com but is not in LEGISCAN_ALLOWLIST. ` +
+          `LegiScan locks keys for ToS abuse and forbids replacements — every call ` +
+          `site must be reviewed against docs/external-api-policy.md before it ships.`,
+      );
+    }
+
+    if (!RESERVE_RPC_RE.test(source)) {
+      failures.push(
+        `${relPath}: fetches api.legiscan.com without calling ` +
+          `reserve_legiscan_api_call. Unmetered calls bypass the daily/monthly ` +
+          `budget and leave no row in legiscan_api_call_log.`,
+      );
+    }
+  }
+
+  if (OPENSTATES_HOST_RE.test(source) && !OPENSTATES_ALLOWLIST.includes(relPath)) {
+    failures.push(
+      `${relPath}: contacts the OpenStates GraphQL endpoint but is not in ` +
+        `OPENSTATES_ALLOWLIST. Route provider calls through ` +
+        `src/lib/openstatesClient.ts so retry and error reporting stay in one place.`,
+    );
+  }
+}
+
+// 3. Throttle defaults must not drift below the policy floors.
+for (const rule of THROTTLE_FLOORS) {
+  const full = path.join(repoRoot, rule.file);
+  if (!fs.existsSync(full)) {
+    failures.push(`${rule.file}: expected to exist so ${rule.constant} can be checked.`);
+    continue;
+  }
+
+  const value = readNumericConstant(fs.readFileSync(full, "utf8"), rule.constant);
+  if (value === null) {
+    failures.push(
+      `${rule.file}: could not find \`const ${rule.constant} = <number>;\`. ` +
+        `The rate-limit guardrail depends on this constant; do not rename or ` +
+        `remove it without updating docs/external-api-policy.md.`,
+    );
+    continue;
+  }
+
+  if (rule.min !== null && rule.min !== undefined && value < rule.min) {
+    failures.push(
+      `${rule.file}: ${rule.constant} is ${value}, below the policy floor of ` +
+        `${rule.min} ${rule.unit}. See docs/external-api-policy.md §3.`,
+    );
+  }
+
+  if (rule.max !== null && rule.max !== undefined && value > rule.max) {
+    failures.push(
+      `${rule.file}: ${rule.constant} is ${value}, above the policy ceiling of ` +
+        `${rule.max} ${rule.unit}. See docs/external-api-policy.md §3.`,
+    );
+  }
+}
+
+if (failures.length > 0) {
+  console.error("External API usage guardrail failed:\n");
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  console.error("\nSee docs/external-api-policy.md");
+  process.exit(1);
+}
+
+console.log("External API usage guardrail passed.");

--- a/src/lib/openstatesClient.ts
+++ b/src/lib/openstatesClient.ts
@@ -136,7 +136,15 @@ async function performQuery<T>(
   });
 
   if (!res.ok) {
-    const message = `OpenStates request failed (${res.status})`;
+    // Always surface the response body. OpenStates answers a query written
+    // against a stale schema with a 400 whose body names the offending field —
+    // and a bare "request failed (400)" hid exactly that for months (the
+    // nightly job queried a root `voteEvents` field that does not exist).
+    const body = await res.text().catch(() => "");
+    const detail = body.slice(0, 500).replace(/\s+/g, " ").trim();
+    const message = detail
+      ? `OpenStates request failed (${res.status}): ${detail}`
+      : `OpenStates request failed (${res.status})`;
     console.error(
       JSON.stringify({
         level: "error",
@@ -144,6 +152,7 @@ async function performQuery<T>(
         msg: "Non-200 response",
         status: res.status,
         statusText: res.statusText,
+        body: detail,
       }),
     );
     if (res.status >= 500 || res.status === 429) {
@@ -210,46 +219,6 @@ function buildCacheKey(billId: string, since?: string | null) {
 }
 
 const BILL_VOTES_QUERY = `
-  query BillVotes($id: String!, $after: String, $since: DateTime) {
-    bill(id: $id) {
-      id
-      identifier
-      title
-      votes(first: 100, after: $after, updatedSince: $since) {
-        pageInfo {
-          hasNextPage
-          endCursor
-        }
-        edges {
-          node {
-            id
-            motionText
-            result
-            startDate
-            updatedAt
-            organization {
-              classification
-              name
-            }
-            bill {
-              id
-              identifier
-            }
-            votes {
-              option
-              voter {
-                id
-                name
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-`;
-
-const BILL_VOTES_QUERY_LEGACY = `
   query BillVotes($id: String!, $after: String) {
     bill(id: $id) {
       id
@@ -289,11 +258,14 @@ const BILL_VOTES_QUERY_LEGACY = `
   }
 `;
 
-let supportsUpdatedSince: boolean | null = null;
-
-const RECENT_VOTE_EVENTS_QUERY = `
-  query RecentVoteEvents($since: DateTime!, $first: Int!, $after: String) {
-    voteEvents(updatedSince: $since, first: $first, after: $after) {
+// OpenStates exposes no root `voteEvents` field and no `DateTime` scalar — the
+// only root entry points are jurisdictions/jurisdiction/people/person/
+// organization/bill/bills, and `updatedSince` is a plain `String`. Recently
+// changed bills are therefore discovered through `bills`, and their vote
+// events are read per bill via BILL_VOTES_QUERY.
+const RECENT_BILLS_QUERY = `
+  query RecentBills($jurisdiction: String!, $since: String!, $first: Int!, $after: String) {
+    bills(jurisdiction: $jurisdiction, updatedSince: $since, first: $first, after: $after) {
       pageInfo {
         hasNextPage
         endCursor
@@ -301,25 +273,8 @@ const RECENT_VOTE_EVENTS_QUERY = `
       edges {
         node {
           id
-          motionText
-          result
-          startDate
+          identifier
           updatedAt
-          organization {
-            classification
-            name
-          }
-          bill {
-            id
-            identifier
-          }
-          votes {
-            option
-            voter {
-              id
-              name
-            }
-          }
         }
       }
     }
@@ -413,69 +368,69 @@ async function queryBillVotes(
   variables: GraphQLVariables,
   apiKey: string,
 ): Promise<BillVotesQueryResult> {
-  // Decide which query variant to use (and detect support on the fly).
-  const sinceValue = (variables as { since?: unknown }).since;
-  const hasSince = sinceValue !== undefined && sinceValue !== null;
-  const shouldUseLegacy = supportsUpdatedSince === false || !hasSince;
-  const runQuery = (query: string) =>
-    withRetry(() => performQuery<BillVotesQueryResult>(query, variables, apiKey));
-
-  if (shouldUseLegacy) {
-    return runQuery(BILL_VOTES_QUERY_LEGACY);
-  }
-
-  try {
-    const data = await runQuery(BILL_VOTES_QUERY);
-    supportsUpdatedSince = true;
-    return data;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (supportsUpdatedSince !== false && /Unknown argument "updatedSince"/.test(message)) {
-      console.warn(
-        JSON.stringify({
-          level: "warn",
-          context: "openstatesClient",
-          msg: "OpenStates schema missing updatedSince argument; falling back",
-        }),
-      );
-      supportsUpdatedSince = false;
-      const legacyVariables = { ...variables };
-      delete (legacyVariables as { since?: unknown }).since;
-      return runQuery(BILL_VOTES_QUERY_LEGACY);
-    }
-    throw error;
-  }
+  // `bill.votes` takes no updatedSince argument, so the whole vote connection
+  // is fetched and `since` is applied client-side in fetchBillVotes.
+  const billVariables = { ...variables };
+  delete (billVariables as { since?: unknown }).since;
+  return withRetry(() =>
+    performQuery<BillVotesQueryResult>(BILL_VOTES_QUERY, billVariables, apiKey)
+  );
 }
 
-export async function fetchRecentVoteEvents(
+export type OpenStatesBillRef = {
+  id: string;
+  identifier: string | null;
+  updatedAt: string | null;
+};
+
+/**
+ * List bills in a jurisdiction touched since `sinceIso`.
+ *
+ * This replaces a root `voteEvents(updatedSince:)` query that OpenStates does
+ * not implement — it returned HTTP 400 on every nightly run. Callers pair the
+ * returned ids with `fetchVotesForBills` to read the vote payloads.
+ */
+export async function fetchRecentlyUpdatedBills(
   apiKey: string,
   sinceIso: string,
-  pageSize = 200,
-): Promise<OpenStatesVoteEvent[]> {
-  const collected: OpenStatesVoteEvent[] = [];
+  jurisdiction = "California",
+  pageSize = 100,
+  maxPages = 20,
+): Promise<OpenStatesBillRef[]> {
+  const collected: OpenStatesBillRef[] = [];
   let after: string | null = null;
   let hasNextPage = true;
+  let page = 0;
 
-  while (hasNextPage) {
-    const data = await withRetry(() =>
-      performQuery<{
-        voteEvents: {
-          pageInfo: PageInfo;
-          edges: Array<{ node: OpenStatesVoteEvent | null }>;
-        };
-      }>(RECENT_VOTE_EVENTS_QUERY, { since: sinceIso, first: pageSize, after }, apiKey)
+  while (hasNextPage && page < maxPages) {
+    const data: {
+      bills: {
+        pageInfo: PageInfo;
+        edges: Array<{ node: OpenStatesBillRef | null }>;
+      } | null;
+    } = await withRetry(() =>
+      performQuery(
+        RECENT_BILLS_QUERY,
+        { jurisdiction, since: sinceIso, first: pageSize, after },
+        apiKey,
+      )
     );
 
-    const edges = data.voteEvents?.edges ?? [];
-    for (const edge of edges) {
-      if (edge?.node?.id) {
-        collected.push(edge.node);
+    for (const edge of data.bills?.edges ?? []) {
+      const node = edge?.node;
+      if (node?.id) {
+        collected.push({
+          id: node.id,
+          identifier: node.identifier ?? null,
+          updatedAt: node.updatedAt ?? null,
+        });
       }
     }
 
-    hasNextPage = Boolean(data.voteEvents?.pageInfo?.hasNextPage);
-    after = data.voteEvents?.pageInfo?.endCursor ?? null;
-    if (!hasNextPage) break;
+    hasNextPage = Boolean(data.bills?.pageInfo?.hasNextPage);
+    after = data.bills?.pageInfo?.endCursor ?? null;
+    page += 1;
+    if (!hasNextPage || !after) break;
   }
 
   return collected;

--- a/src/lib/openstatesClient.ts
+++ b/src/lib/openstatesClient.ts
@@ -296,10 +296,9 @@ export async function fetchBillVotes(
   let lastBillMeta: { identifier: string | null; title: string | null } | null = null;
 
   while (hasNextPage) {
-    const variables: GraphQLVariables = { id: billId, after };
-    if (sinceIso) variables.since = sinceIso;
-
-    const data = await queryBillVotes(variables, apiKey);
+    // `sinceIso` is deliberately not sent: `bill.votes` has no updatedSince
+    // argument. It is applied to the cache key and as a client-side filter.
+    const data = await queryBillVotes({ id: billId, after }, apiKey);
 
     const bill = data.bill;
     if (!bill) {
@@ -364,16 +363,12 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function queryBillVotes(
+function queryBillVotes(
   variables: GraphQLVariables,
   apiKey: string,
 ): Promise<BillVotesQueryResult> {
-  // `bill.votes` takes no updatedSince argument, so the whole vote connection
-  // is fetched and `since` is applied client-side in fetchBillVotes.
-  const billVariables = { ...variables };
-  delete (billVariables as { since?: unknown }).since;
   return withRetry(() =>
-    performQuery<BillVotesQueryResult>(BILL_VOTES_QUERY, billVariables, apiKey)
+    performQuery<BillVotesQueryResult>(BILL_VOTES_QUERY, variables, apiKey)
   );
 }
 
@@ -396,7 +391,7 @@ export async function fetchRecentlyUpdatedBills(
   jurisdiction = "California",
   pageSize = 100,
   maxPages = 20,
-): Promise<OpenStatesBillRef[]> {
+): Promise<{ bills: OpenStatesBillRef[]; truncated: boolean }> {
   const collected: OpenStatesBillRef[] = [];
   let after: string | null = null;
   let hasNextPage = true;
@@ -433,5 +428,22 @@ export async function fetchRecentlyUpdatedBills(
     if (!hasNextPage || !after) break;
   }
 
-  return collected;
+  // Report rather than silently swallow the cap, so a caller that stopped short
+  // of the real window can say so instead of looking like a complete sync.
+  const truncated = hasNextPage && page >= maxPages;
+  if (truncated) {
+    console.warn(
+      JSON.stringify({
+        level: "warn",
+        context: "openstatesClient",
+        msg: "Bill listing truncated at page cap",
+        jurisdiction,
+        sinceIso,
+        maxPages,
+        collected: collected.length,
+      }),
+    );
+  }
+
+  return { bills: collected, truncated };
 }

--- a/supabase/functions/bulk-import-dataset/index.ts
+++ b/supabase/functions/bulk-import-dataset/index.ts
@@ -62,10 +62,17 @@ const RELEVANT_SEARCH_PHRASES = [
 // surfaced a groundwater-sustainability act among the results. Every candidate
 // is therefore confirmed against the actual bill text on leginfo (free, no API
 // quota) before it is written to `bills`.
-const VERIFY_PHRASE_REGEX = new RegExp(
-  `(${RELEVANT_SEARCH_PHRASES.join("|")})`,
-  "i",
-);
+//
+// This must be derived from the same phrase list the sweep searches for. When
+// it was pinned to the built-in constant, overriding BULK_IMPORT_SEARCH_PHRASES
+// made discovery search the new terms while verification still only accepted
+// the old ones — every hit failed and was written to the permanent rejection
+// cache.
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const buildVerifyRegex = (phrases: string[]): RegExp =>
+  new RegExp(`(${phrases.map(escapeRegExp).join("|")})`, "i");
 
 const BROWSER_HEADERS = {
   "User-Agent":
@@ -160,6 +167,7 @@ type SearchDiscoveryStats = {
   verify_attempted: number;
   verified_count: number;
   rejected_count: number;
+  unverifiable_count: number;
   verify_unavailable: number;
   error_count: number;
   errors: string[];
@@ -736,28 +744,39 @@ const setPendingState = async (
 };
 
 /**
- * Fetch a CA bill's text from leginfo and report whether it actually discusses
- * one of the tracked topics. Returns null when the page could not be read, so
- * the caller can retry later instead of rejecting the bill outright.
+ * Outcome of confirming a candidate against the real bill text.
+ *
+ * `unavailable` is distinct from `rejected` so a transient leginfo failure
+ * retries later, while `unverifiable` (no usable link — a condition retrying
+ * can never fix) drops the row instead of parking it in the queue forever.
  */
+type VerifyOutcome = "match" | "rejected" | "unavailable" | "unverifiable";
+
 const billTextMentionsTopic = async (
   stateLink: string | null,
-): Promise<boolean | null> => {
-  if (!stateLink) return null;
+  verifyRegex: RegExp,
+): Promise<VerifyOutcome> => {
+  if (!stateLink) return "unverifiable";
+
+  let billId: string | null;
+  try {
+    billId = new URL(stateLink).searchParams.get("bill_id");
+  } catch {
+    return "unverifiable";
+  }
+  if (!billId) return "unverifiable";
 
   try {
-    const billId = new URL(stateLink).searchParams.get("bill_id");
-    if (!billId) return null;
-
     const response = await fetch(
       `https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=${billId}`,
       { headers: BROWSER_HEADERS },
     );
-    if (!response.ok) return null;
+    if (!response.ok) return "unavailable";
 
     const html = await response.text();
     const anchor = html.indexOf('id="bill_all"');
-    if (anchor < 0) return null;
+    // No text published yet (introduced but not printed): worth retrying.
+    if (anchor < 0) return "unavailable";
 
     const text = html
       .slice(anchor)
@@ -765,10 +784,10 @@ const billTextMentionsTopic = async (
       .replace(/&nbsp;/g, " ")
       .replace(/\s+/g, " ");
 
-    return VERIFY_PHRASE_REGEX.test(text);
+    return verifyRegex.test(text) ? "match" : "rejected";
   } catch (error) {
     console.warn("leginfo verification fetch failed", { error: String(error) });
-    return null;
+    return "unavailable";
   }
 };
 
@@ -808,6 +827,7 @@ const runSearchDiscovery = async (
     verify_attempted: 0,
     verified_count: 0,
     rejected_count: 0,
+    unverifiable_count: 0,
     verify_unavailable: 0,
     error_count: 0,
     errors: [],
@@ -980,6 +1000,7 @@ const runSearchDiscovery = async (
   const verifyDelayMs = getVerifyDelayMs();
   const maxNewBills = getSearchMaxNewBills();
 
+  const verifyRegex = buildVerifyRegex(phrases);
   const verified: BillSeedRow[] = [];
   const deferred: BillSeedRow[] = [];
   let index = 0;
@@ -993,22 +1014,26 @@ const runSearchDiscovery = async (
     if (stats.verify_attempted > 0) await delay(verifyDelayMs);
     stats.verify_attempted += 1;
 
-    const mentionsTopic = await billTextMentionsTopic(row.state_link);
+    const outcome = await billTextMentionsTopic(row.state_link, verifyRegex);
 
-    if (mentionsTopic === null) {
-      // Text unavailable (not yet published, transient failure). Keep it queued
+    if (outcome === "unavailable") {
+      // Text not published yet, or a transient leginfo failure. Keep it queued
       // and retry on a later run rather than dropping or wrongly admitting it.
       stats.verify_unavailable += 1;
       deferred.push(row);
       continue;
     }
 
-    if (mentionsTopic) {
+    if (outcome === "match") {
       verified.push(row);
-    } else {
-      stats.rejected_count += 1;
-      rejected.add(row.id);
+      continue;
     }
+
+    // "rejected" (text has none of the phrases) and "unverifiable" (no usable
+    // link, which retrying can never fix) both leave the queue for good.
+    stats.rejected_count += 1;
+    if (outcome === "unverifiable") stats.unverifiable_count += 1;
+    rejected.add(row.id);
   }
 
   stats.verified_count = verified.length;
@@ -1025,7 +1050,11 @@ const runSearchDiscovery = async (
         .upsert(chunk, { onConflict: "id", ignoreDuplicates: true });
 
       if (error) {
+        // Requeue rather than drop: these rows already passed verification, and
+        // the search sweep that found them is on a multi-hour cooldown, so
+        // losing them here would strand them until the phrase is searched again.
         pushError(`insert batch @${i}: ${error.message ?? String(error)}`);
+        deferred.push(...chunk);
         continue;
       }
 

--- a/supabase/functions/bulk-import-dataset/index.ts
+++ b/supabase/functions/bulk-import-dataset/index.ts
@@ -32,7 +32,48 @@ const RELEVANT_KEYWORDS = [
 
 const KEYWORD_REGEX = new RegExp(`\\b(${RELEVANT_KEYWORDS.join("|")})\\b`, "i");
 
+// The LegiScan dataset only carries bill metadata (title + the "An act to
+// amend …" description), so a title/description keyword match cannot see terms
+// that appear in the operative bill text. CA AB2691 ("Elections: elective
+// office: felony conviction.") is the canonical example: the disqualifying
+// crimes "sexual assault" and "human trafficking" only appear in Section 1.
+// These phrases are therefore run through LegiScan's full-text search engine,
+// which indexes the bill text itself.
+const RELEVANT_SEARCH_PHRASES = [
+  "human trafficking",
+  "sex trafficking",
+  "labor trafficking",
+  "trafficking victim",
+  "commercial sexual exploitation",
+  "sexual exploitation",
+  "sexual assault",
+  "sexual abuse",
+  "sexual violence",
+  "child sexual abuse",
+  "domestic violence",
+  "intimate partner violence",
+  "forced labor",
+  "involuntary servitude",
+  "prostitution",
+];
+
+// LegiScan's search engine ranks by relevance rather than matching the quoted
+// phrase exactly, so a raw search hit is a *candidate*, not a match: a dry run
+// surfaced a groundwater-sustainability act among the results. Every candidate
+// is therefore confirmed against the actual bill text on leginfo (free, no API
+// quota) before it is written to `bills`.
+const VERIFY_PHRASE_REGEX = new RegExp(
+  `(${RELEVANT_SEARCH_PHRASES.join("|")})`,
+  "i",
+);
+
+const BROWSER_HEADERS = {
+  "User-Agent":
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+};
+
 const CURSOR_KEY_PREFIX = "bulk_import_dataset";
+const SEARCH_PENDING_KEY_PREFIX = "bulk_import_search_pending";
 const DEFAULT_FILES_PER_INVOCATION = 10000;
 const MAX_FILES_PER_INVOCATION = 10000;
 const DEFAULT_UPSERT_BATCH_SIZE = 40;
@@ -42,6 +83,23 @@ const DEFAULT_MAX_RUNTIME_MS = 18_000;
 const HARD_MAX_RUNTIME_MS = 26_000;
 const DEADLINE_GUARD_MS = 1_250;
 const DATASET_LIST_CACHE_KEY_PREFIX = "legiscan_dataset_list";
+const DEFAULT_SEARCH_PAGES_PER_PHRASE = 2;
+const MAX_SEARCH_PAGES_PER_PHRASE = 20;
+// LegiScan's Terms of Service treat rapid bursts as abuse and will lock the API
+// key. Space search calls out and keep the per-run total small; the per-page
+// cooldown means unqueried phrases are simply picked up on a later run.
+const DEFAULT_SEARCH_DELAY_MS = 1_500;
+const DEFAULT_SEARCH_MAX_CALLS_PER_RUN = 6;
+const DEFAULT_VERIFY_PER_RUN = 8;
+const DEFAULT_VERIFY_DELAY_MS = 250;
+const MAX_PENDING_QUEUE = 2_000;
+const MAX_REJECTED_TRACKED = 5_000;
+const DEFAULT_SEARCH_MIN_RELEVANCE = 50;
+const DEFAULT_SEARCH_MAX_NEW_BILLS = 250;
+// The active CA snapshot is ~26 MB zipped (~35 MB once base64-encoded), which
+// exceeds what an Edge Function worker can decode without being terminated.
+// Skip the download above this size instead of losing the whole invocation.
+const DEFAULT_MAX_DATASET_BYTES = 20_000_000;
 
 type SupabaseAdminClient = any;
 
@@ -51,6 +109,9 @@ type LegiScanDataset = {
   access_key: string;
   session_title?: string;
   dataset_hash?: string;
+  dataset_size?: number | string;
+  year_start?: number | string;
+  year_end?: number | string;
 };
 
 type BillSeedRow = {
@@ -77,6 +138,32 @@ type CursorState = {
 type RequestOptions = {
   force_restart: boolean;
   max_files: number;
+  dry_run: boolean;
+  skip_search: boolean;
+  skip_dataset: boolean;
+};
+
+type SearchDiscoveryStats = {
+  enabled: boolean;
+  dry_run: boolean;
+  phrases_queried: number;
+  pages_fetched: number;
+  pages_skipped_by_guardrails: number;
+  results_seen: number;
+  candidate_bills: number;
+  new_bills: number;
+  inserted_count: number;
+  capped: boolean;
+  aborted: string | null;
+  abort_message: string | null;
+  pending_queue_size: number;
+  verify_attempted: number;
+  verified_count: number;
+  rejected_count: number;
+  verify_unavailable: number;
+  error_count: number;
+  errors: string[];
+  sample_new_bills: Array<{ id: number; bill_number: string; title: string }>;
 };
 
 type BatchStats = {
@@ -159,13 +246,17 @@ const readRequestOptions = async (req: Request): Promise<RequestOptions> => {
     MAX_FILES_PER_INVOCATION,
   );
 
-  const forceRestart = url.searchParams.get("force_restart") === "1" ||
-    url.searchParams.get("force_restart") === "true" ||
-    body?.force_restart === true;
+  const flag = (name: string): boolean =>
+    url.searchParams.get(name) === "1" ||
+    url.searchParams.get(name) === "true" ||
+    body?.[name] === true;
 
   return {
-    force_restart: forceRestart,
+    force_restart: flag("force_restart"),
     max_files: maxFiles,
+    dry_run: flag("dry_run"),
+    skip_search: flag("skip_search"),
+    skip_dataset: flag("skip_dataset"),
   };
 };
 
@@ -200,6 +291,94 @@ const getDatasetCooldownSeconds = (): number =>
   parsePositiveInt(
     Deno.env.get("LEGISCAN_DATASET_COOLDOWN_SECONDS"),
     7 * 24 * 60 * 60,
+    31 * 24 * 60 * 60,
+  );
+
+/**
+ * Cooldown used while a dataset cursor pass is still in progress. The full
+ * cooldown assumes one download per snapshot, but a bounded cursor pass needs
+ * many invocations over the same snapshot to finish; applying the weekly
+ * cooldown to those freezes the pass permanently.
+ */
+const getDatasetResumeCooldownSeconds = (): number =>
+  parsePositiveInt(
+    Deno.env.get("LEGISCAN_DATASET_RESUME_COOLDOWN_SECONDS"),
+    6 * 60 * 60,
+    31 * 24 * 60 * 60,
+  );
+
+const getMaxDatasetBytes = (): number =>
+  parsePositiveInt(
+    Deno.env.get("BULK_IMPORT_MAX_DATASET_BYTES"),
+    DEFAULT_MAX_DATASET_BYTES,
+    Number.MAX_SAFE_INTEGER,
+  );
+
+const datasetPassEnabled = (): boolean =>
+  (Deno.env.get("BULK_IMPORT_DATASET_PASS") ?? "true").toLowerCase() !==
+    "false";
+
+const searchDiscoveryEnabled = (): boolean =>
+  (Deno.env.get("BULK_IMPORT_SEARCH_DISCOVERY") ?? "true").toLowerCase() !==
+    "false";
+
+const getSearchPhrases = (): string[] => {
+  const raw = Deno.env.get("BULK_IMPORT_SEARCH_PHRASES");
+  if (!raw) return RELEVANT_SEARCH_PHRASES;
+
+  const phrases = raw
+    .split("|")
+    .map((phrase) => phrase.trim())
+    .filter((phrase) => phrase.length > 0);
+
+  return phrases.length > 0 ? phrases : RELEVANT_SEARCH_PHRASES;
+};
+
+const getSearchPagesPerPhrase = (): number =>
+  parsePositiveInt(
+    Deno.env.get("BULK_IMPORT_SEARCH_PAGES_PER_PHRASE"),
+    DEFAULT_SEARCH_PAGES_PER_PHRASE,
+    MAX_SEARCH_PAGES_PER_PHRASE,
+  );
+
+const getSearchMinRelevance = (): number => {
+  const raw = Deno.env.get("BULK_IMPORT_SEARCH_MIN_RELEVANCE");
+  if (raw === null || raw === undefined || raw === "") {
+    return DEFAULT_SEARCH_MIN_RELEVANCE;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return DEFAULT_SEARCH_MIN_RELEVANCE;
+  return Math.max(0, Math.min(Math.floor(parsed), 100));
+};
+
+const getSearchMaxNewBills = (): number =>
+  parsePositiveInt(
+    Deno.env.get("BULK_IMPORT_SEARCH_MAX_NEW_BILLS"),
+    DEFAULT_SEARCH_MAX_NEW_BILLS,
+    5000,
+  );
+
+const getSearchDelayMs = (): number =>
+  parsePositiveInt(
+    Deno.env.get("LEGISCAN_SEARCH_DELAY_MS"),
+    DEFAULT_SEARCH_DELAY_MS,
+    10_000,
+  );
+
+const getSearchMaxCallsPerRun = (): number =>
+  parsePositiveInt(
+    Deno.env.get("LEGISCAN_SEARCH_MAX_CALLS_PER_RUN"),
+    DEFAULT_SEARCH_MAX_CALLS_PER_RUN,
+    50,
+  );
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const getSearchCooldownSeconds = (): number =>
+  parsePositiveInt(
+    Deno.env.get("LEGISCAN_SEARCH_COOLDOWN_SECONDS"),
+    20 * 60 * 60,
     31 * 24 * 60 * 60,
   );
 
@@ -447,7 +626,429 @@ const flushUpsertBatch = async (
   return { inserted, updated };
 };
 
-console.log("Initializing bulk-import-dataset v39 bounded cursor import");
+const toNullableInt = (value: unknown): number | null => {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? Math.trunc(parsed) : null;
+};
+
+/**
+ * CA bill status permalink, matching the `state_link` LegiScan reports in the
+ * dataset (e.g. `…?bill_id=202520260AB2691`). `sync-updated-bills` scrapes this
+ * URL for the bill text, so seeding it avoids a LegiScan `getBill` call per
+ * newly discovered bill.
+ */
+const buildCaStateLink = (
+  billNumber: string,
+  yearStart: number | null,
+  yearEnd: number | null,
+): string | null => {
+  if (!billNumber || yearStart === null || yearEnd === null) return null;
+  return "https://leginfo.legislature.ca.gov/faces/billStatusClient.xhtml" +
+    `?bill_id=${yearStart}${yearEnd}0${billNumber}`;
+};
+
+const selectExistingBillIds = async (
+  supabaseAdmin: SupabaseAdminClient,
+  billIds: number[],
+): Promise<Set<number>> => {
+  const existing = new Set<number>();
+  const chunkSize = 500;
+
+  for (let i = 0; i < billIds.length; i += chunkSize) {
+    const chunk = billIds.slice(i, i + chunkSize);
+    const { data, error } = await supabaseAdmin
+      .from("bills")
+      .select("id")
+      .in("id", chunk);
+
+    if (error) throw error;
+    (data ?? []).forEach((row: { id: number }) => existing.add(Number(row.id)));
+  }
+
+  return existing;
+};
+
+const getVerifyPerRun = (): number =>
+  parsePositiveInt(
+    Deno.env.get("BULK_IMPORT_VERIFY_PER_RUN"),
+    DEFAULT_VERIFY_PER_RUN,
+    100,
+  );
+
+const getVerifyDelayMs = (): number =>
+  parsePositiveInt(
+    Deno.env.get("BULK_IMPORT_VERIFY_DELAY_MS"),
+    DEFAULT_VERIFY_DELAY_MS,
+    5_000,
+  );
+
+type PendingState = {
+  rows: BillSeedRow[];
+  rejected: number[];
+};
+
+const pendingKey = (state: string, sessionId: number): string =>
+  `${SEARCH_PENDING_KEY_PREFIX}:${state.toLowerCase()}:${sessionId}`;
+
+const getPendingState = async (
+  supabaseAdmin: SupabaseAdminClient,
+  key: string,
+): Promise<PendingState> => {
+  const { data, error } = await supabaseAdmin
+    .from("ingestion_cursors")
+    .select("cursor")
+    .eq("key", key)
+    .maybeSingle();
+
+  if (error) throw error;
+
+  const cursor = data?.cursor ?? {};
+  return {
+    rows: Array.isArray(cursor.rows) ? cursor.rows as BillSeedRow[] : [],
+    rejected: Array.isArray(cursor.rejected)
+      ? (cursor.rejected as unknown[]).map(Number).filter(Number.isFinite)
+      : [],
+  };
+};
+
+const setPendingState = async (
+  supabaseAdmin: SupabaseAdminClient,
+  key: string,
+  state: PendingState,
+): Promise<void> => {
+  const nowIso = new Date().toISOString();
+  const { error } = await supabaseAdmin
+    .from("ingestion_cursors")
+    .upsert(
+      {
+        key,
+        cursor: {
+          rows: state.rows.slice(0, MAX_PENDING_QUEUE),
+          rejected: state.rejected.slice(-MAX_REJECTED_TRACKED),
+          updated_at: nowIso,
+        },
+        updated_at: nowIso,
+      },
+      { onConflict: "key" },
+    );
+
+  if (error) throw error;
+};
+
+/**
+ * Fetch a CA bill's text from leginfo and report whether it actually discusses
+ * one of the tracked topics. Returns null when the page could not be read, so
+ * the caller can retry later instead of rejecting the bill outright.
+ */
+const billTextMentionsTopic = async (
+  stateLink: string | null,
+): Promise<boolean | null> => {
+  if (!stateLink) return null;
+
+  try {
+    const billId = new URL(stateLink).searchParams.get("bill_id");
+    if (!billId) return null;
+
+    const response = await fetch(
+      `https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=${billId}`,
+      { headers: BROWSER_HEADERS },
+    );
+    if (!response.ok) return null;
+
+    const html = await response.text();
+    const anchor = html.indexOf('id="bill_all"');
+    if (anchor < 0) return null;
+
+    const text = html
+      .slice(anchor)
+      .replace(/<[^>]*>/g, " ")
+      .replace(/&nbsp;/g, " ")
+      .replace(/\s+/g, " ");
+
+    return VERIFY_PHRASE_REGEX.test(text);
+  } catch (error) {
+    console.warn("leginfo verification fetch failed", { error: String(error) });
+    return null;
+  }
+};
+
+/**
+ * Discover relevant bills through LegiScan's full-text search engine.
+ *
+ * The dataset pass can only match the bill title, so bills that address these
+ * topics in their operative text are invisible to it. One `getSearch` call per
+ * (phrase, page) is reserved through the same guardrails as the dataset calls.
+ */
+const runSearchDiscovery = async (
+  supabaseAdmin: SupabaseAdminClient,
+  legiscanApiKey: string,
+  options: {
+    sessionId: number;
+    state: string;
+    yearStart: number | null;
+    yearEnd: number | null;
+    dryRun: boolean;
+    stopAt: number;
+  },
+): Promise<SearchDiscoveryStats> => {
+  const stats: SearchDiscoveryStats = {
+    enabled: true,
+    dry_run: options.dryRun,
+    phrases_queried: 0,
+    pages_fetched: 0,
+    pages_skipped_by_guardrails: 0,
+    results_seen: 0,
+    candidate_bills: 0,
+    new_bills: 0,
+    inserted_count: 0,
+    capped: false,
+    aborted: null,
+    abort_message: null,
+    pending_queue_size: 0,
+    verify_attempted: 0,
+    verified_count: 0,
+    rejected_count: 0,
+    verify_unavailable: 0,
+    error_count: 0,
+    errors: [],
+    sample_new_bills: [],
+  };
+
+  const pushError = (message: string) => {
+    stats.error_count += 1;
+    if (stats.errors.length < ERROR_PREVIEW_LIMIT) stats.errors.push(message);
+  };
+
+  const phrases = getSearchPhrases();
+  const pagesPerPhrase = getSearchPagesPerPhrase();
+  const minRelevance = getSearchMinRelevance();
+  const cooldownSeconds = getSearchCooldownSeconds();
+  const delayMs = getSearchDelayMs();
+  const maxCallsPerRun = getSearchMaxCallsPerRun();
+  const candidates = new Map<number, BillSeedRow>();
+
+  let callsMade = 0;
+
+  phraseLoop:
+  for (const phrase of phrases) {
+    if (Date.now() >= options.stopAt - DEADLINE_GUARD_MS) break;
+
+    let queriedPhrase = false;
+    let pageTotal = 1;
+
+    for (let page = 1; page <= Math.min(pagesPerPhrase, pageTotal); page += 1) {
+      if (Date.now() >= options.stopAt - DEADLINE_GUARD_MS) break;
+
+      if (callsMade >= maxCallsPerRun) {
+        stats.aborted = "max_calls_per_run";
+        break phraseLoop;
+      }
+
+      const reservation = await reserveLegiScanCall(
+        supabaseAdmin,
+        "getSearch",
+        `${options.state}:${options.sessionId}:${phrase}:p${page}`,
+        cooldownSeconds,
+      );
+
+      if (!reservation.allowed) {
+        stats.pages_skipped_by_guardrails += 1;
+        break;
+      }
+
+      // Throttle: LegiScan locks keys for bursty traffic.
+      if (callsMade > 0) await delay(delayMs);
+      callsMade += 1;
+
+      const searchUrl = `https://api.legiscan.com/?key=${legiscanApiKey}` +
+        `&op=getSearch&id=${options.sessionId}` +
+        `&query=${encodeURIComponent(`"${phrase}"`)}&page=${page}`;
+
+      try {
+        const response = await fetch(searchUrl, {
+          headers: LEGISCAN_API_HEADERS,
+        });
+        const json = await response.json();
+
+        if (json?.status !== "OK" || !json?.searchresult) {
+          // An API-level error (locked key, exhausted quota, malformed query)
+          // will repeat for every remaining phrase. Stop the whole sweep rather
+          // than issuing another dozen doomed requests.
+          stats.aborted = "legiscan_error";
+          stats.abort_message = toNullableString(json?.alert?.message) ??
+            `LegiScan getSearch returned ${json?.status ?? response.status}`;
+          pushError(`${phrase} (page ${page}): ${stats.abort_message}`);
+          break phraseLoop;
+        }
+
+        stats.pages_fetched += 1;
+        if (!queriedPhrase) {
+          queriedPhrase = true;
+          stats.phrases_queried += 1;
+        }
+
+        const searchResult = json.searchresult as Record<string, unknown>;
+        const summary = (searchResult.summary ?? {}) as Record<string, unknown>;
+        pageTotal = Math.max(1, toNullableInt(summary.page_total) ?? 1);
+
+        for (const [key, value] of Object.entries(searchResult)) {
+          if (key === "summary" || !value || typeof value !== "object") {
+            continue;
+          }
+
+          const result = value as Record<string, unknown>;
+          stats.results_seen += 1;
+
+          const relevance = toNullableInt(result.relevance) ?? 0;
+          if (relevance < minRelevance) continue;
+
+          const billId = parseBillId(result.bill_id);
+          const billNumber = toNullableString(result.bill_number);
+          const title = toNullableString(result.title);
+          if (!billId || !billNumber || !title) continue;
+
+          if (!candidates.has(billId)) {
+            candidates.set(billId, {
+              id: billId,
+              bill_number: billNumber,
+              title,
+              description: null,
+              status: null,
+              state_link: buildCaStateLink(
+                billNumber,
+                options.yearStart,
+                options.yearEnd,
+              ),
+              change_hash: toNullableString(result.change_hash),
+              summary_simple: null,
+            });
+          }
+        }
+      } catch (error) {
+        pushError(
+          `${phrase} (page ${page}): ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        break;
+      }
+    }
+  }
+
+  stats.candidate_bills = candidates.size;
+
+  // Candidates are queued rather than inserted directly: verification costs a
+  // leginfo fetch per bill, so it is metered across runs while the search sweep
+  // (which is rate-limited by LegiScan) runs at its own pace.
+  const queueKey = pendingKey(options.state, options.sessionId);
+  const pending = await getPendingState(supabaseAdmin, queueKey);
+  const rejected = new Set<number>(pending.rejected);
+  const queued = new Map<number, BillSeedRow>(
+    pending.rows.map((row) => [row.id, row]),
+  );
+
+  const newCandidates = Array.from(candidates.values()).filter(
+    (row) => !rejected.has(row.id) && !queued.has(row.id),
+  );
+
+  const existingIds = await selectExistingBillIds(
+    supabaseAdmin,
+    Array.from(
+      new Set([...newCandidates.map((r) => r.id), ...queued.keys()]),
+    ),
+  );
+
+  for (const row of newCandidates) {
+    if (!existingIds.has(row.id)) queued.set(row.id, row);
+  }
+  // Anything already imported (by the dataset pass or a previous run) leaves
+  // the queue.
+  for (const id of existingIds) queued.delete(id);
+
+  const queue = Array.from(queued.values());
+  stats.new_bills = queue.length;
+  stats.pending_queue_size = queue.length;
+  stats.sample_new_bills = queue.slice(0, ERROR_PREVIEW_LIMIT).map((row) => ({
+    id: row.id,
+    bill_number: row.bill_number,
+    title: row.title,
+  }));
+
+  if (options.dryRun) return stats;
+
+  const verifyPerRun = getVerifyPerRun();
+  const verifyDelayMs = getVerifyDelayMs();
+  const maxNewBills = getSearchMaxNewBills();
+
+  const verified: BillSeedRow[] = [];
+  const deferred: BillSeedRow[] = [];
+  let index = 0;
+
+  for (; index < queue.length; index += 1) {
+    if (stats.verify_attempted >= verifyPerRun) break;
+    if (Date.now() >= options.stopAt - DEADLINE_GUARD_MS) break;
+    if (verified.length >= maxNewBills) break;
+
+    const row = queue[index];
+    if (stats.verify_attempted > 0) await delay(verifyDelayMs);
+    stats.verify_attempted += 1;
+
+    const mentionsTopic = await billTextMentionsTopic(row.state_link);
+
+    if (mentionsTopic === null) {
+      // Text unavailable (not yet published, transient failure). Keep it queued
+      // and retry on a later run rather than dropping or wrongly admitting it.
+      stats.verify_unavailable += 1;
+      deferred.push(row);
+      continue;
+    }
+
+    if (mentionsTopic) {
+      verified.push(row);
+    } else {
+      stats.rejected_count += 1;
+      rejected.add(row.id);
+    }
+  }
+
+  stats.verified_count = verified.length;
+  stats.capped = verified.length >= maxNewBills;
+
+  if (verified.length > 0) {
+    const insertBatchSize = getUpsertBatchSize();
+    for (let i = 0; i < verified.length; i += insertBatchSize) {
+      const chunk = verified.slice(i, i + insertBatchSize);
+      // Insert-only: existing rows keep their summaries, status and text, which
+      // `sync-updated-bills` owns.
+      const { error } = await supabaseAdmin
+        .from("bills")
+        .upsert(chunk, { onConflict: "id", ignoreDuplicates: true });
+
+      if (error) {
+        pushError(`insert batch @${i}: ${error.message ?? String(error)}`);
+        continue;
+      }
+
+      stats.inserted_count += chunk.length;
+    }
+  }
+
+  // Everything not resolved this run stays queued, with deferred rows moved to
+  // the back so one unreadable bill cannot block the queue.
+  const remaining = [...queue.slice(index), ...deferred];
+  stats.pending_queue_size = remaining.length;
+
+  await setPendingState(supabaseAdmin, queueKey, {
+    rows: remaining,
+    rejected: Array.from(rejected),
+  });
+
+  return stats;
+};
+
+console.log(
+  "Initializing bulk-import-dataset v40: full-text discovery + bounded cursor import",
+);
 
 serve(async (req) => {
   if (req.method === "OPTIONS") {
@@ -547,7 +1148,41 @@ serve(async (req) => {
     const accessKey = activeDataset.access_key;
     if (!accessKey) throw new Error("Active dataset access_key is missing.");
 
+    // Full-text discovery runs first and commits its own rows, so a later
+    // failure in the (much heavier) dataset pass cannot discard it.
+    const searchDiscovery: SearchDiscoveryStats | { enabled: false } =
+      options.skip_search || !searchDiscoveryEnabled()
+        ? { enabled: false }
+        : await runSearchDiscovery(supabaseAdmin, legiscanApiKey, {
+          sessionId,
+          state,
+          yearStart: toNullableInt(activeDataset.year_start),
+          yearEnd: toNullableInt(activeDataset.year_end),
+          dryRun: options.dry_run,
+          stopAt,
+        });
+
+    // Newly discovered bills carry metadata only; `sync-updated-bills` fetches
+    // their text and summaries. Enqueue here so discovery still drives the
+    // downstream pipeline on the (now common) runs where the dataset pass is
+    // skipped.
+    const discoverySummarySync = "inserted_count" in searchDiscovery &&
+        searchDiscovery.inserted_count > 0
+      ? await enqueueSummarySyncs(
+        supabaseAdmin,
+        getSummarySyncInvocationCount(searchDiscovery.inserted_count),
+      )
+      : null;
+
+    const respond = (body: Record<string, unknown>, status = 200) =>
+      jsonResponse({
+        ...body,
+        search_discovery: searchDiscovery,
+        discovery_summary_sync: discoverySummarySync,
+      }, status);
+
     const datasetHash = activeDataset.dataset_hash ?? null;
+    const datasetSize = toNullableInt(activeDataset.dataset_size);
     const cursorKey = buildCursorKey(state, sessionId);
 
     const existingCursor = options.force_restart
@@ -567,7 +1202,7 @@ serve(async (req) => {
         supabaseAdmin,
         getSummarySyncInvocationCount(0),
       );
-      return jsonResponse({
+      return respond({
         message:
           "Dataset cursor already completed for active session hash. Skipping dataset download.",
         session_id: sessionId,
@@ -587,8 +1222,53 @@ serve(async (req) => {
       });
     }
 
+    if (options.skip_dataset || !datasetPassEnabled()) {
+      return respond({
+        message: "Dataset pass disabled; full-text discovery only.",
+        session_id: sessionId,
+        cursor_key: cursorKey,
+        dataset_hash_present: Boolean(datasetHash),
+        skipped_download: true,
+        legiscan: {
+          dataset_list_source: datasetListSource,
+          calls: legiscanCalls,
+        },
+        continuation: {
+          has_more: false,
+          next_index: existingCursor?.next_index ?? 0,
+          total_files: existingCursor?.total_files ?? 0,
+        },
+      });
+    }
+
+    const maxDatasetBytes = getMaxDatasetBytes();
+    if (datasetSize !== null && datasetSize > maxDatasetBytes) {
+      // Downloading and base64-decoding a snapshot this large terminates the
+      // worker before the cursor can be written, so the pass would never
+      // advance and the LegiScan call would be spent for nothing.
+      return respond({
+        message:
+          "Skipped LegiScan dataset download because the snapshot exceeds the Edge Function size budget.",
+        session_id: sessionId,
+        cursor_key: cursorKey,
+        dataset_hash_present: Boolean(datasetHash),
+        skipped_download: true,
+        dataset_size: datasetSize,
+        max_dataset_bytes: maxDatasetBytes,
+        legiscan: {
+          dataset_list_source: datasetListSource,
+          calls: legiscanCalls,
+        },
+        continuation: {
+          has_more: true,
+          next_index: existingCursor?.next_index ?? 0,
+          total_files: existingCursor?.total_files ?? 0,
+        },
+      });
+    }
+
     if (Date.now() >= stopAt - DEADLINE_GUARD_MS) {
-      return jsonResponse({
+      return respond({
         message:
           "Runtime budget reached before dataset download; invoke again to continue.",
         session_id: sessionId,
@@ -607,16 +1287,25 @@ serve(async (req) => {
       });
     }
 
+    // A partially-walked cursor needs to re-download the same snapshot on the
+    // next invocation, so the weekly cooldown only applies once a pass has
+    // finished. The daily/monthly LegiScan budgets still bound the total.
+    const passInProgress = existingCursor?.session_id === sessionId &&
+      existingCursor?.state === state &&
+      !existingCursor?.completed_at;
+
     const datasetReservation = await reserveLegiScanCall(
       supabaseAdmin,
       "getDataset",
       `${state}:${sessionId}:${datasetHash ?? "no-hash"}`,
-      getDatasetCooldownSeconds(),
+      passInProgress
+        ? getDatasetResumeCooldownSeconds()
+        : getDatasetCooldownSeconds(),
     );
     legiscanCalls.push(datasetReservation);
 
     if (!datasetReservation.allowed) {
-      return jsonResponse({
+      return respond({
         message:
           "Skipped LegiScan dataset download because API guardrails denied the request.",
         session_id: sessionId,
@@ -658,15 +1347,17 @@ serve(async (req) => {
     const totalFiles = billFiles.length;
     const nowIso = new Date().toISOString();
 
-    const sameDataset = existingCursor?.session_id === sessionId &&
-      existingCursor?.state === state &&
-      (
-        datasetHash
-          ? existingCursor.dataset_hash === datasetHash
-          : existingCursor.total_files === totalFiles
-      );
+    // Resume an unfinished pass even when the snapshot hash moved on. LegiScan
+    // republishes the dataset roughly weekly, so keying resumption on the hash
+    // restarted the walk at index 0 every week and the cursor never advanced
+    // past the first batch. Files are name-sorted, so the index stays a valid
+    // position across snapshots, and every upsert is idempotent.
+    const sameSession = existingCursor?.session_id === sessionId &&
+      existingCursor?.state === state;
 
-    const startIndex = sameDataset
+    const resumePass = sameSession && !existingCursor?.completed_at;
+
+    const startIndex = resumePass
       ? Math.max(0, Math.min(existingCursor?.next_index ?? 0, totalFiles))
       : 0;
 
@@ -683,7 +1374,7 @@ serve(async (req) => {
 
       await setCursor(supabaseAdmin, cursorKey, cursor);
 
-      return jsonResponse({
+      return respond({
         message: "No bill files found in dataset.",
         session_id: sessionId,
         cursor_key: cursorKey,
@@ -705,12 +1396,25 @@ serve(async (req) => {
       });
     }
 
-    if (sameDataset && startIndex >= totalFiles && !options.force_restart) {
+    if (resumePass && startIndex >= totalFiles && !options.force_restart) {
+      // Reachable when a newer snapshot carries fewer bill files than the one
+      // the cursor was walking. Close the pass out so the next snapshot starts
+      // a fresh walk instead of re-entering this branch forever.
+      await setCursor(supabaseAdmin, cursorKey, {
+        session_id: sessionId,
+        state,
+        dataset_hash: datasetHash,
+        next_index: startIndex,
+        total_files: totalFiles,
+        completed_at: nowIso,
+        updated_at: nowIso,
+      });
+
       const summarySync = await enqueueSummarySyncs(
         supabaseAdmin,
         getSummarySyncInvocationCount(0),
       );
-      return jsonResponse({
+      return respond({
         message: "Dataset already fully processed for current cursor.",
         session_id: sessionId,
         cursor_key: cursorKey,
@@ -839,7 +1543,7 @@ serve(async (req) => {
       getSummarySyncInvocationCount(summarySyncCandidateCount),
     );
 
-    return jsonResponse({
+    return respond({
       message: hasMore
         ? "Processed bounded dataset batch. Invoke again to continue."
         : "Bulk import completed for active dataset cursor.",

--- a/supabase/functions/votes-daily/index.ts
+++ b/supabase/functions/votes-daily/index.ts
@@ -52,7 +52,7 @@ serve(async (req) => {
     const sinceIso = await resolveSinceIso(req.url, supabaseAdmin);
     log("info", "Fetching updates", { sinceIso });
 
-    const recentBills = await fetchRecentlyUpdatedBills(
+    const { bills: recentBills, truncated } = await fetchRecentlyUpdatedBills(
       openStatesKey,
       sinceIso,
       JURISDICTION,
@@ -72,6 +72,7 @@ serve(async (req) => {
     log("info", "Recently updated bills fetched", {
       bills: recentBills.length,
       candidateBills: candidateIds.length,
+      truncated,
     });
 
     // Only bills already tracked in Supabase are worth fetching votes for; the
@@ -179,6 +180,7 @@ serve(async (req) => {
       since: sinceIso,
       jurisdiction: JURISDICTION,
       candidateBills: candidateIds.length,
+      candidateBillsTruncated: truncated,
       trackedBills: trackedIds.length,
       processedBills,
       voteEventsUpserted: totalVoteEvents,

--- a/supabase/functions/votes-daily/index.ts
+++ b/supabase/functions/votes-daily/index.ts
@@ -5,7 +5,7 @@ import { serve } from "https://deno.land/std@0.223.0/http/server.ts";
 import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
 
 import {
-  fetchRecentVoteEvents,
+  fetchRecentlyUpdatedBills,
   fetchVotesForBills,
 } from "../../../src/lib/openstatesClient.ts";
 import { syncBillVoteEvents, type BillContext } from "../_shared/votes/syncVotes.ts";
@@ -16,6 +16,8 @@ import { isAuthorizedCronOrAdmin } from "../_shared/auth.ts";
 const JOB_KEY = "votes-daily:last-run";
 const FALLBACK_WINDOW_MS = 1000 * 60 * 60 * 48; // 48 hours
 const PREVIEW_LIMIT = 10;
+const JURISDICTION = Deno.env.get("OPENSTATES_JURISDICTION") ?? "California";
+const BILL_LOOKUP_CHUNK = 200;
 
 serve(async (req) => {
   if (req.method === "OPTIONS") {
@@ -50,9 +52,14 @@ serve(async (req) => {
     const sinceIso = await resolveSinceIso(req.url, supabaseAdmin);
     log("info", "Fetching updates", { sinceIso });
 
-    const events = await fetchRecentVoteEvents(openStatesKey, sinceIso);
-    if (!events.length) {
-      log("info", "No recent vote events detected");
+    const recentBills = await fetchRecentlyUpdatedBills(
+      openStatesKey,
+      sinceIso,
+      JURISDICTION,
+    );
+
+    if (!recentBills.length) {
+      log("info", "No recently updated bills detected");
       await upsertJobState(supabaseAdmin, new Date().toISOString());
       return new Response(
         JSON.stringify({ message: "No new vote events", since: sinceIso, processedBills: 0 }),
@@ -60,56 +67,58 @@ serve(async (req) => {
       );
     }
 
-    const billIds = new Set<string>();
-    const eventsWithoutBill: string[] = [];
-    for (const event of events) {
-      const billId = event.bill?.id;
-      if (!billId) {
-        eventsWithoutBill.push(event.id);
-        continue;
-      }
-      billIds.add(billId);
-    }
+    const candidateIds = Array.from(new Set(recentBills.map((bill) => bill.id)));
 
-    log("info", "Recent vote events fetched", {
-      events: events.length,
-      candidateBills: billIds.size,
-      eventsWithoutBill,
+    log("info", "Recently updated bills fetched", {
+      bills: recentBills.length,
+      candidateBills: candidateIds.length,
     });
 
-    if (billIds.size === 0) {
+    // Only bills already tracked in Supabase are worth fetching votes for; the
+    // jurisdiction query returns every bill the state touched in the window,
+    // which after a long gap is thousands of ids. PostgREST puts `.in()` values
+    // in the query string, so the lookup is chunked to keep the URL bounded.
+    const billMap = new Map<string, BillContext>();
+
+    for (let i = 0; i < candidateIds.length; i += BILL_LOOKUP_CHUNK) {
+      const chunk = candidateIds.slice(i, i + BILL_LOOKUP_CHUNK);
+      const { data: billRows, error: billsError } = await supabaseAdmin
+        .from("bills")
+        .select("id,bill_number,title,openstates_bill_id")
+        .in("openstates_bill_id", chunk);
+
+      if (billsError) throw billsError;
+
+      for (const row of billRows ?? []) {
+        if (!row?.openstates_bill_id) continue;
+        billMap.set(row.openstates_bill_id, {
+          id: row.id,
+          openstates_bill_id: row.openstates_bill_id,
+          bill_number: row.bill_number ?? null,
+          title: row.title ?? null,
+        });
+      }
+    }
+
+    const trackedIds = Array.from(billMap.keys());
+
+    if (trackedIds.length === 0) {
+      log("info", "No recently updated bills are tracked in Supabase", {
+        candidateBills: candidateIds.length,
+      });
       await upsertJobState(supabaseAdmin, new Date().toISOString());
       return new Response(
         JSON.stringify({
-          message: "Events lacked bill metadata",
+          message: "No tracked bills changed",
           since: sinceIso,
+          candidateBills: candidateIds.length,
           processedBills: 0,
-          eventsWithoutBill,
         }),
-        { headers: { ...corsHeaders, "Content-Type": "application/json" }, status: 207 },
+        { headers: { ...corsHeaders, "Content-Type": "application/json" } },
       );
     }
 
-    const billIdList = Array.from(billIds);
-    const { data: billRows, error: billsError } = await supabaseAdmin
-      .from("bills")
-      .select("id,bill_number,title,openstates_bill_id")
-      .in("openstates_bill_id", billIdList);
-
-    if (billsError) throw billsError;
-
-    const billMap = new Map<string, BillContext>();
-    for (const row of billRows ?? []) {
-      if (!row?.openstates_bill_id) continue;
-      billMap.set(row.openstates_bill_id, {
-        id: row.id,
-        openstates_bill_id: row.openstates_bill_id,
-        bill_number: row.bill_number ?? null,
-        title: row.title ?? null,
-      });
-    }
-
-    const bundles = await fetchVotesForBills(openStatesKey, billIdList, { sinceIso, batchSize: 3 });
+    const bundles = await fetchVotesForBills(openStatesKey, trackedIds, { sinceIso, batchSize: 3 });
 
     let processedBills = 0;
     let totalVoteEvents = 0;
@@ -117,15 +126,9 @@ serve(async (req) => {
     let skippedBillsCount = 0;
     const skippedBillsPreview: Array<{ provider_bill_id: string; reason: string }> = [];
 
-    for (const billId of billIdList) {
+    for (const billId of trackedIds) {
       const billContext = billMap.get(billId);
-      if (!billContext) {
-        skippedBillsCount += 1;
-        if (skippedBillsPreview.length < PREVIEW_LIMIT) {
-          skippedBillsPreview.push({ provider_bill_id: billId, reason: "No matching bill in Supabase" });
-        }
-        continue;
-      }
+      if (!billContext) continue;
 
       const bundle = bundles.get(billId);
       if (!bundle || !bundle.events.length) {
@@ -154,7 +157,7 @@ serve(async (req) => {
           voteRecordsProcessed,
         });
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
+        const message = errorToMessage(err);
         log("error", "Failed syncing bill", {
           billId: billContext.id,
           billNumber: billContext.bill_number,
@@ -174,12 +177,14 @@ serve(async (req) => {
 
     const summary = {
       since: sinceIso,
+      jurisdiction: JURISDICTION,
+      candidateBills: candidateIds.length,
+      trackedBills: trackedIds.length,
       processedBills,
       voteEventsUpserted: totalVoteEvents,
       voteRecordsUpserted: totalVoteRecords,
       skippedBillsCount,
       skippedBillsPreview,
-      eventsWithoutBill,
     };
 
     log("info", "Daily sync summary", summary);
@@ -189,7 +194,7 @@ serve(async (req) => {
       status: skippedBillsCount ? 207 : 200,
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorToMessage(error);
     log("error", "Fatal daily sync error", { error: message });
     return new Response(JSON.stringify({ error: message }), {
       headers: { ...corsHeaders, "Content-Type": "application/json" },
@@ -237,6 +242,23 @@ async function upsertJobState(
   if (error) {
     log("error", "Failed updating job_state", { error: error.message });
   }
+}
+
+function errorToMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object") {
+    const maybe = error as { message?: unknown; details?: unknown; hint?: unknown; code?: unknown };
+    const parts = [maybe.message, maybe.details, maybe.hint, maybe.code]
+      .filter((part) => typeof part === "string" && part.length > 0);
+    if (parts.length) return parts.join(" | ");
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return String(error);
+    }
+  }
+  return String(error);
 }
 
 function log(


### PR DESCRIPTION
## Summary

Bill ingestion had been stalled since April 2026 and `votes-daily` had been failing on **every** run. Both were invisible from the scheduler: `cron.job_run_details` showed `daily-bill-sync` succeeding daily and `cron_job_errors` was empty, because the SQL wrapper only enqueues the HTTP request. This is the "cron success ≠ ingestion success" trap `AGENTS.md` §5 warns about.

Reported symptom: **AB2691** should be in Supabase (it addresses human trafficking and sexual assault in Section 1) and was not.

## Diagnosis

### Why ingestion stopped after April 2026

`ingestion_cursors → bulk_import_dataset:ca:2172` read `next_index: 160, total_files: 4987, completed_at: null`, untouched since `2026-06-17`. `bills` held 83 rows, newest `created_at` 2026-04-30. Three compounding causes:

| Cause | Evidence |
| --- | --- |
| `getDataset` guardrail (added 2026-05-01) permits one download/week, but a bounded cursor pass needs ~31 invocations to walk 4,987 files | `legiscan_api_call_log`, `20260501130000_legiscan_api_usage_guardrails.sql` |
| Cursor only resumed when `dataset_hash` matched; LegiScan republishes the CA snapshot weekly, so `startIndex` reset to 0 every week | five distinct hashes Jun 19 → Jul 21 |
| CA snapshot is 26,051,065 bytes (~35 MB base64) — decoding it terminates the worker before the cursor is written | cursor never advanced on any of the five permitted download dates |

### Why AB2691 specifically could never be imported

The dataset filter tested **`title` only**:

- title: `Elections: elective office: felony conviction.`
- LegiScan description: `An act to amend Section 20 of the Elections Code, relating to elections.`

Neither contains a keyword — the terms appear only in the Legislative Counsel's Digest and Section 1. **The LegiScan dataset carries no bill text**, so fixing the cursor alone would never have found it. Its neighbours AB2674 (2121751) and AB2701 (2121778) are both in `bills`; AB2691 sits between them, was scanned on 2026-04-30, and was skipped.

### Why votes-daily failed

```
Unknown type "DateTime".
Cannot query field "voteEvents" on type "Query".
```

The job queried a root `voteEvents(updatedSince: DateTime)` field that **does not exist**. Introspection confirms the only root fields are `jurisdictions`, `jurisdiction`, `people`, `person`, `organization`, `bill`, `bills`, and `updatedSince` is a plain `String`. `votes-backfill` kept working because it uses `bill(id:)`.

## Changes

**`bulk-import-dataset`** — full-text discovery via LegiScan `getSearch`, with every candidate confirmed against the real bill text on leginfo (free, no quota) before insert. A dry run showed search relevance alone is far too loose, surfacing a groundwater-sustainability act. Candidates are queued in `ingestion_cursors` and verified 8/run, with a rejection cache. Plus the three cursor/cooldown/size fixes above.

**External API guardrails** — see below.

**`votes-daily` / `openstatesClient`** — discovery moved to `bills(jurisdiction:, updatedSince:)`, verified by introspection. Removed a second dead query variant whose fallback never fired (the 400 message didn't match the string it tested for). Non-2xx responses now include the GraphQL error body. Tracked-bill lookup chunked; Supabase rejections serialized properly instead of `[object Object]`.

## API guardrails

On 2026-07-26 the LegiScan key was **locked for ToS abuse** after a sweep issued 23 `getSearch` calls in ~20 seconds. Every call individually satisfied `reserve_legiscan_api_call` — it meters per-resource cooldowns and quota, but nothing limited *rate*, and nothing required new code to meter at all.

- **`docs/external-api-policy.md`** — provider's published limits (30k queries/month, per-operation refresh table), self-imposed rate floors (≥1000 ms between calls, ≤6/invocation, never concurrent, abort on first `status: "ERROR"`), the incident record, and kill switches. **Never register a replacement key** — restoration is api@legiscan.com only.
- **`mobile-app/scripts/check-external-api-usage.js`** — CI-enforced, following the existing `check:public-env` / `check:admin-web-only` convention. Allowlist of files permitted to contact each provider, mandatory `reserve_legiscan_api_call`, and throttle constants held at or above policy floors. It caught two previously unlisted OpenStates call sites on first run.

## Verification

Deployed and exercised against production (`bulk-import-dataset` v95, `votes-daily` v46):

| | before | after |
| --- | --- | --- |
| votes-daily status | 500 | **207** |
| `vote_events` | 162 | **164** |
| `vote_records` | 4,704 | **4,733** |

- `bulk-import-dataset` verified to make **zero** LegiScan calls while reservations are on cooldown (`pages_skipped_by_guardrails: 15`).
- Guardrail verified to fail correctly (dropped the delay constant to 50 ms → CI error).
- All three CI guardrails pass; `syncVotes` tests pass; both functions type-check under Deno.

## Known limitations

- **Bill ingestion stays offline until LegiScan restores the API key.** The discovery path is deployed but cannot run.
- The verification gate has never run against live LegiScan results (the key locked first). Thresholds are env-tunable; the first real run's `search_discovery` block should be watched.
- votes-daily catch-up is capped at 20 pages (~2,000 bills). Irrelevant for the nightly 48h window; a multi-month gap would truncate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
