### PR TITLE
docs: correct the incident burst rate to the measured figure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,8 +111,8 @@ parts via `yarn workspace mobile-app check:external-api`.
 The non-negotiables:
 
 - The LegiScan key is single and irreplaceable. It was locked once already
-  (2026-07-26) for issuing 23 requests in ~20 seconds. **Never register a
-  replacement key** — restoration goes through api@legiscan.com only.
+  (2026-07-26) for issuing 23 requests in 3.2 seconds (~7/second). **Never
+  register a replacement key** — restoration goes through api@legiscan.com only.
 - Every LegiScan request goes through `public.reserve_legiscan_api_call`, and
   is skipped when the reservation is not `allowed`.
 - Rate floors: ≥ 1000 ms between calls, ≤ 6 calls per invocation, never

--- a/docs/external-api-policy.md
+++ b/docs/external-api-policy.md
@@ -16,17 +16,29 @@ CI enforces the mechanical parts via
 
 **2026-07-26: the LegiScan API key was locked.**
 
-A discovery sweep issued **23 `getSearch` calls in roughly 20 seconds** while
-being tested. LegiScan's response:
+A discovery sweep issued **23 `getSearch` calls in 3.2 seconds** — about **7
+requests per second** — while being tested. LegiScan's response:
 
 > API key has been locked because of a violation of the Terms of Service
 > abusing public services, please contact api@legiscan.com to restore access.
 > Creating additional API keys will result in permanent suspension.
 
 The per-call guardrails (`reserve_legiscan_api_call`) were all satisfied — each
-call was individually within its cooldown and quota. What tripped the lock was
-**request rate**, which nothing in the system limited at the time. That is why
-§3 exists as a separate rule from §2.
+call was individually within its cooldown and quota. Monthly usage at the time
+was 29 of the 30,000 allowance, so quota was never a factor. What tripped the
+lock was **request rate**, which nothing in the system limited. That is why §3
+exists as a separate rule from §2.
+
+The rate above is measured, not estimated — `public.legiscan_api_call_log`
+records one row per reserved call, so the true burst window is:
+
+```sql
+select count(*),
+       extract(epoch from (max(created_at) - min(created_at))) as span_seconds
+from public.legiscan_api_call_log
+where endpoint = 'getSearch'
+  and created_at >= timestamptz '2026-07-26 03:00:00+00';
+```
 
 **Never register a replacement key.** Restoration goes through
 api@legiscan.com only.

--- a/mobile-app/scripts/check-external-api-usage.js
+++ b/mobile-app/scripts/check-external-api-usage.js
@@ -1,11 +1,12 @@
 // Guards the external-API rules in docs/external-api-policy.md.
 //
 // Context: on 2026-07-26 the LegiScan API key was locked for ToS abuse after a
-// sweep issued 23 getSearch calls in ~20 seconds. Every individual call passed
-// the reserve_legiscan_api_call cooldown/quota check — nothing in the system
-// limited *rate*, and nothing stopped a new file from calling LegiScan without
-// metering at all. LegiScan forbids registering a replacement key, so this
-// failure mode is close to unrecoverable and is worth failing CI over.
+// sweep issued 23 getSearch calls in 3.2 seconds (~7/second). Every individual
+// call passed the reserve_legiscan_api_call cooldown/quota check — nothing in
+// the system limited *rate*, and nothing stopped a new file from calling
+// LegiScan without metering at all. LegiScan forbids registering a replacement
+// key, so this failure mode is close to unrecoverable and is worth failing CI
+// over.
 //
 // Checks:
 //   1. Only allowlisted files may contact LegiScan or OpenStates at all.


### PR DESCRIPTION
The incident record in `docs/external-api-policy.md` (and its two echoes in
`AGENTS.md` and `check-external-api-usage.js`) said the LegiScan key was locked
after **23 requests in "~20 seconds"**. That figure was inferred from
surrounding timestamps rather than read from the call log.

The measured window, from `public.legiscan_api_call_log`:

| | |
| --- | --- |
| Requests | 23 |
| First → last | 03:12:32.936 → 03:12:36.109 UTC |
| Span | **3.2 seconds** |
| Rate | **~7 requests/second** |

Why it's worth a commit: ~1/second reads as borderline — the kind of thing a
reasonable person might argue about — which undersells why the key was locked
and makes the 1500 ms floor in §3 look arbitrary. At ~7/second the floor is
self-evidently necessary, and anyone reading the policy later draws the right
conclusion about how much headroom they have.

Also in this change:

* Records that monthly usage was 29 of the 30,000 allowance at the time, making
  explicit that quota was never a factor and the lock was purely rate-based.
* Includes the SQL that measures the burst window, so the number is reproducible
  rather than remembered.

No behaviour change — comments and docs only. The rate-limit constants the
guardrail enforces are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
